### PR TITLE
Sc 29670 PLCC navbar link updated to point to QHack 2023

### DIFF
--- a/pennylane_sphinx_theme/navbar.py
+++ b/pennylane_sphinx_theme/navbar.py
@@ -28,8 +28,8 @@ NAVBAR_LEFT = [
         "href": "https://pennylane.ai/blog/",
     },
     {
-        "name": "<i class='fas fa-campground'></i> Code Camp",
-        "href": "https://codecamp.xanadu.ai/",
+        "name": "QHack 2023",
+        "href": "https://qhack.ai/",
     },
 ]
 


### PR DESCRIPTION
**Context:** [story-29670-pl-website-navbar-change-from-plcc-to-qhack-2023](https://app.shortcut.com/xanaduai/story/29670/pl-website-navbar-change-from-plcc-to-qhack-2023)

**Description of the Change:** Changing PLCC navbar link to QHack 2023 as a part of the soft launch

**Benefits:** N/A

**Possible Drawbacks:** N/A

**Related GitHub Issues:** N/A
