### PR TITLE
SC 30758 Update QML Navlink to Learn 

### DIFF
--- a/pennylane_sphinx_theme/navbar.py
+++ b/pennylane_sphinx_theme/navbar.py
@@ -4,7 +4,7 @@ This module contains the common PennyLane navigation bar data.
 
 NAVBAR_LEFT = [
     {
-        "name": "Quantum machine learning",
+        "name": "Learn",
         "href": "https://pennylane.ai/qml/",
     },
     {


### PR DESCRIPTION
[sc-30758-change-qml-to-learn-in-navbar](https://app.shortcut.com/xanaduai/story/30758/change-qml-to-learn-in-navbar)
Quick PR to change 'Quantum Machine Learning' to 'Learn' for access to future hubs.

Will be merged in when Superhub and Subhubs are ready for prod. 