### PR TITLE
Remove deprecated ::set-output.

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -9,10 +9,14 @@ This release contains contributions from (in alphabetical order):
 ### Improvements
 
 - Bumped `wheel` to v0.38.1. [(#18)](https://github.com/PennyLaneAI/pennylane-sphinx-theme/pull/18)
+- Remove deprecated `set-output` commands from workflow files.
+  [(#25)](https://github.com/PennyLaneAI/pennylane-sphinx-theme/pull/25)
 
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
+
+Vincent Michaud-Rioux
 
 ## Release 0.3.2 (current release)
 

--- a/.github/workflows/post_release_version_bump.yml
+++ b/.github/workflows/post_release_version_bump.yml
@@ -18,8 +18,8 @@ jobs:
           old_version=`grep -oP '(?<=__version__ = ").*(?=")' pennylane_sphinx_theme/_version.py`
           new_version=`echo $old_version | awk '{split($0,v,"."); print v[1] "." v[2]+1 ".0-dev"}'`
 
-          echo "::set-output name=old_version::$old_version"
-          echo "::set-output name=new_version::$new_version"
+          echo "old_version=$old_version" >> $GITHUB_OUTPUT
+          echo "new_version=$new_version" >> $GITHUB_OUTPUT
 
       - name: Bump version in _version.py
         run:

--- a/.github/workflows/pre_release_version_bump.yml
+++ b/.github/workflows/pre_release_version_bump.yml
@@ -16,8 +16,8 @@ jobs:
           old_version=`grep -oP '(?<=__version__ = ").*(?=")' pennylane_sphinx_theme/_version.py`
           new_version=${old_version%-dev}
 
-          echo "::set-output name=old_version::$old_version"
-          echo "::set-output name=new_version::$new_version"
+          echo "old_version=$old_version" >> $GITHUB_OUTPUT
+          echo "new_version=$new_version" >> $GITHUB_OUTPUT
 
       - name: Bump version in _version.py
         run:


### PR DESCRIPTION
**Context:**
`save-state` and `set-output` commands will be deprecated. 
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

**Description of the Change:**
Use new env files instead of `save-state` and `set-output` commands.

**Benefits:**
CI will keep running.

**Possible Drawbacks:**
None.

**Related GitHub Issues:**
None.
