### PR TITLE
Add links to PennyLane Challenges page

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,10 +1,22 @@
-## Release 0.5.0 (development release)
+## Release 0.4.2 (current release)
+
+### Improvements
+
+* Added a link to the PennyLane Challenges page in the navbar and footer.
+  [(#33)](https://github.com/PennyLaneAI/pennylane-sphinx-theme/pull/33)
+
+### Bug Fixes
+
+* Removed a link to the PennyLane FAQ page from the footer.
+  [(#33)](https://github.com/PennyLaneAI/pennylane-sphinx-theme/pull/33)
 
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
 
-## Release 0.4.1 (current release)
+[Mikhail Andrenkov](https://github.com/Mandrenkov).
+
+## Release 0.4.1
 
 ### Bug Fixes
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -10,6 +10,9 @@
 * Removed a link to the PennyLane FAQ page from the footer.
   [(#33)](https://github.com/PennyLaneAI/pennylane-sphinx-theme/pull/33)
 
+* Removed the "external" icon from the API and Catalyst links in the navbar.
+  [(#33)](https://github.com/PennyLaneAI/pennylane-sphinx-theme/pull/33)
+
 ### Contributors
 
 This release contains contributions from (in alphabetical order):

--- a/pennylane_sphinx_theme/_version.py
+++ b/pennylane_sphinx_theme/_version.py
@@ -3,4 +3,4 @@ This module specifies the PennyLane Sphinx Theme version with https://semver.org
 using the following format: <major>.<minor>.<patch>[-<pre-release>].
 """
 
-__version__ = "0.5.0-dev"
+__version__ = "0.4.2"

--- a/pennylane_sphinx_theme/footer.py
+++ b/pennylane_sphinx_theme/footer.py
@@ -92,10 +92,6 @@ FOOTER = {
                     "name": "Glossary",
                     "href": "https://pennylane.ai/qml/glossary/",
                 },
-                {
-                    "name": "FAQ",
-                    "href": "https://pennylane.ai/faq/",
-                },
             ],
         },
         {

--- a/pennylane_sphinx_theme/footer.py
+++ b/pennylane_sphinx_theme/footer.py
@@ -81,6 +81,10 @@ FOOTER = {
                     "href": "https://pennylane.ai/qml/videos",
                 },
                 {
+                    "name": "Challenges",
+                    "href": "https://pennylane.ai/challenges/",
+                },
+                {
                     "name": "Demos",
                     "href": "https://pennylane.ai/qml/demonstrations",
                 },

--- a/pennylane_sphinx_theme/navbar.py
+++ b/pennylane_sphinx_theme/navbar.py
@@ -16,10 +16,10 @@ NAVBAR_LEFT = [
                 "href": "https://codebook.xanadu.ai/",
                 "external": True,
             },
-            # {
-            #     "name": "Challenges",
-            #     "href": "https://pennylane.ai/challenges/",
-            # },
+            {
+                "name": "Challenges",
+                "href": "https://pennylane.ai/challenges/",
+            },
             {
                 "name": "Videos",
                 "href": "https://pennylane.ai/qml/videos/",

--- a/pennylane_sphinx_theme/navbar.py
+++ b/pennylane_sphinx_theme/navbar.py
@@ -49,7 +49,6 @@ NAVBAR_LEFT = [
             {
                 "name": "API",
                 "href": "https://docs.pennylane.ai/en/stable/code/qml.html",
-                "external": True,
             },
             {
                 "name": "Devices",
@@ -63,7 +62,6 @@ NAVBAR_LEFT = [
             {
                 "name": "Catalyst",
                 "href": "https://docs.pennylane.ai/projects/catalyst/",
-                "external": True,
             },
         ],
     },


### PR DESCRIPTION
**Context:**

The [PennyLane Challenges](https://pennylane.ai/challenges/) page is now live!

**Description of the Change:**

This PR makes the links in the navbar and footer consistent with the PennyLane website such that:
1. There is a link to the PennyLane Challenges page in the navbar and footer.
2. There is no longer a link to the PennyLane FAQ in the footer.

It also removes the "external" icon from the API and Catalyst links in the navbar.

**Benefits:**

* The navbar and footer are consistent between the PennyLane website and the Docs pages.

**Possible Drawbacks:**

None.

**Related GitHub Issues:**

None.

---

**Preview:** https://xanaduai-pennylane--33.com.readthedocs.build/projects/sphinx-theme/en/33/.