### PR TITLE
Add links to PennyLane Performance page

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,4 +1,9 @@
-## Release 0.5.0 (development release)
+## Release 0.4.3 (current release)
+
+### Improvements
+
+* Added links to the PennyLane Performance page in the navbar and footer.
+  [(#35)](https://github.com/PennyLaneAI/pennylane-sphinx-theme/pull/35)
 
 ### Contributors
 

--- a/pennylane_sphinx_theme/_version.py
+++ b/pennylane_sphinx_theme/_version.py
@@ -3,4 +3,4 @@ This module specifies the PennyLane Sphinx Theme version with https://semver.org
 using the following format: <major>.<minor>.<patch>[-<pre-release>].
 """
 
-__version__ = "0.5.0-dev"
+__version__ = "0.4.3"

--- a/pennylane_sphinx_theme/footer.py
+++ b/pennylane_sphinx_theme/footer.py
@@ -44,6 +44,10 @@ FOOTER = {
                     "href": "https://pennylane.ai/datasets/",
                 },
                 {
+                    "name": "Performance",
+                    "href": "https://pennylane.ai/performance/",
+                },
+                {
                     "name": "Learn",
                     "href": "https://pennylane.ai/qml/",
                 },
@@ -116,6 +120,10 @@ FOOTER = {
                 {
                     "name": "Demos",
                     "href": "https://pennylane.ai/qml/demonstrations",
+                },
+                {
+                    "name": "Performance",
+                    "href": "https://pennylane.ai/performance/",
                 },
                 {
                     "name": "Devices",

--- a/pennylane_sphinx_theme/navbar.py
+++ b/pennylane_sphinx_theme/navbar.py
@@ -32,10 +32,10 @@ NAVBAR_LEFT = [
                 "name": "Education",
                 "href": "https://pennylane.ai/education/",
             },
-            # {
-            #     "name": "Performance",
-            #     "href": "https://pennylane.ai/performance/",
-            # },
+            {
+                "name": "Performance",
+                "href": "https://pennylane.ai/performance/",
+            },
             {
                 "name": "FAQ",
                 "href": "https://pennylane.ai/faq/",


### PR DESCRIPTION
**Context:**

The [PennyLane Performance](https://pennylane.ai/performance/) page is now live!

**Description of the Change:**

This PR adds links to the PennyLane Performance in the navbar and footer.

Navbar             |  Footer
:-------------------------:|:-------------------------:
![](https://github.com/PennyLaneAI/pennylane-sphinx-theme/assets/5883774/4ab44a9d-509a-4bf0-80b0-fd496b74367c)  |  ![](https://github.com/PennyLaneAI/pennylane-sphinx-theme/assets/5883774/fbe891d8-30da-453b-a203-29b1c1817477)

**Benefits:**

* The content of the navbar and footer are consistent between the PennyLane website and the Docs pages.

**Possible Drawbacks:**

None.

**Related GitHub Issues:**

None.

---

**Preview:** https://xanaduai-pennylane--35.com.readthedocs.build/projects/sphinx-theme/en/35/