### PR TITLE
Restore support for Python 3.7

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -3,7 +3,6 @@
 ### Improvements
 
 * Bumped `pillow` to v10.0.1. [(#37)](https://github.com/PennyLaneAI/pennylane-sphinx-theme/pull/37)
-* Dropped support for Python 3.7. [(#37)](https://github.com/PennyLaneAI/pennylane-sphinx-theme/pull/37)
 
 ### Contributors
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,8 +1,15 @@
 ## Release 0.5.0 (development release)
 
+### Improvements
+
+* Bumped `pillow` to v10.0.1. [(#37)](https://github.com/PennyLaneAI/pennylane-sphinx-theme/pull/37)
+* Dropped support for Python 3.7. [(#37)](https://github.com/PennyLaneAI/pennylane-sphinx-theme/pull/37)
+
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
+
+[Mikhail Andrenkov](https://github.com/Mandrenkov).
 
 ## Release 0.4.3 (current release)
 
@@ -14,6 +21,8 @@ This release contains contributions from (in alphabetical order):
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
+
+[Mikhail Andrenkov](https://github.com/Mandrenkov).
 
 ## Release 0.4.2 (current release)
 
@@ -72,8 +81,8 @@ This release contains contributions from (in alphabetical order):
 
 ### Improvements
 
-- Bumped `wheel` to v0.38.1. [(#18)](https://github.com/PennyLaneAI/pennylane-sphinx-theme/pull/18)
-- Remove deprecated `set-output` commands from workflow files.
+* Bumped `wheel` to v0.38.1. [(#18)](https://github.com/PennyLaneAI/pennylane-sphinx-theme/pull/18)
+* Remove deprecated `set-output` commands from workflow files.
   [(#25)](https://github.com/PennyLaneAI/pennylane-sphinx-theme/pull/25)
 
 ### Contributors
@@ -86,13 +95,13 @@ Vincent Michaud-Rioux
 
 ### Improvements
 
-- Minor changes and bugfixes.
+* Minor changes and bugfixes.
 
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
 
-[Josh Izaac](https://github.com/josh146)
+[Josh Izaac](https://github.com/josh146).
 
 ## Release 0.3.0
 
@@ -104,4 +113,4 @@ This release contains contributions from (in alphabetical order):
 
 This release contains contributions from (in alphabetical order):
 
-[Josh Izaac](https://github.com/josh146)
+[Josh Izaac](https://github.com/josh146).

--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,7 @@ Installation
 
 .. installation-start-inclusion-marker-do-not-remove
 
-The PennyLane Sphinx Theme requires Python 3.8 or later. The latest version of the
+The PennyLane Sphinx Theme requires Python 3.7 or later. The latest version of the
 theme can be installed directly using ``pip``:
 
 .. code-block:: bash

--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,7 @@ Installation
 
 .. installation-start-inclusion-marker-do-not-remove
 
-The PennyLane Sphinx Theme requires Python 3.7 or later. The latest version of the
+The PennyLane Sphinx Theme requires Python 3.8 or later. The latest version of the
 theme can be installed directly using ``pip``:
 
 .. code-block:: bash

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
**Context:**

PR #37 dropped support for Python 3.7 but this was not necessary as the `pillow` version is not pinned in `setup.py`.

**Description of the Change:**

* Restored support for Python 3.7 in `setup.py`.
* Added a note about the Pillow upgrade to the changelog.
* Fixed a number of changelog formatting inconsistencies.

**Benefits:**

* Existing projects that use Python 3.7 are no incompatible with the PennyLane Sphinx Theme.
* The changelog is up-to-date.

**Possible Drawbacks:**

None.

**Related GitHub Issues:**

None.