### PR TITLE
Bump XST version to v0.5.0

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,8 +1,10 @@
-## Release 0.5.0 (development release)
+## Release 0.5.0 (current release)
 
 ### Improvements
 
 * Bumped `pillow` to v10.0.1. [(#37)](https://github.com/PennyLaneAI/pennylane-sphinx-theme/pull/37)
+
+* Bumped the XST version to v0.5.0. [(#40)](https://github.com/PennyLaneAI/pennylane-sphinx-theme/pull/40)
 
 ### Contributors
 
@@ -10,7 +12,7 @@ This release contains contributions from (in alphabetical order):
 
 [Mikhail Andrenkov](https://github.com/Mandrenkov).
 
-## Release 0.4.3 (current release)
+## Release 0.4.3
 
 ### Improvements
 
@@ -23,7 +25,7 @@ This release contains contributions from (in alphabetical order):
 
 [Mikhail Andrenkov](https://github.com/Mandrenkov).
 
-## Release 0.4.2 (current release)
+## Release 0.4.2
 
 ### Improvements
 

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -5,4 +5,5 @@ pillow==10.0.1
 sphinx==4.5.0
 sphinx-copybutton
 sphinx-gallery==0.10.1
-xanadu-sphinx-theme==0.4.0
+# TODO: Replace this requirement with a versioned release.
+xanadu-sphinx-theme @ git+https://github.com/XanaduAI/xanadu-sphinx-theme@sc-46517-accessibility-improvements

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -5,5 +5,4 @@ pillow==10.0.1
 sphinx==4.5.0
 sphinx-copybutton
 sphinx-gallery==0.10.1
-# TODO: Replace this requirement with a versioned release.
-xanadu-sphinx-theme @ git+https://github.com/XanaduAI/xanadu-sphinx-theme@sc-46517-accessibility-improvements
+xanadu-sphinx-theme==0.5.0

--- a/pennylane_sphinx_theme/footer.py
+++ b/pennylane_sphinx_theme/footer.py
@@ -148,6 +148,11 @@ FOOTER = {
             "href": "https://github.com/PennyLaneAI/pennylane",
         },
         {
+            "name": "Discord",
+            "icon": "bx bxl-discord",
+            "href": "https://discord.com/invite/paYuHUA5hE",
+        },
+        {
             "name": "LinkedIn",
             "icon": "bx bxl-linkedin",
             "href": "https://linkedin.com/company/xanaduai/",

--- a/pennylane_sphinx_theme/footer.py
+++ b/pennylane_sphinx_theme/footer.py
@@ -138,30 +138,37 @@ FOOTER = {
     ],
     "footer_social_icons": [
         {
+            "name": "Twitter",
             "icon": "bx bxl-twitter",
             "href": "https://twitter.com/PennyLaneAI",
         },
         {
+            "name": "GitHub",
             "icon": "bx bxl-github",
             "href": "https://github.com/PennyLaneAI/pennylane",
         },
         {
+            "name": "LinkedIn",
             "icon": "bx bxl-linkedin",
             "href": "https://linkedin.com/company/xanaduai/",
         },
         {
+            "name": "Discourse",
             "icon": "bx bxl-discourse",
             "href": "https://discuss.pennylane.ai",
         },
         {
+            "name": "YouTube",
             "icon": "bx bxl-youtube",
             "href": "https://www.youtube.com/@pennylaneai/",
         },
         {
+            "name": "Slack",
             "icon": "bx bxl-slack",
             "href": "https://xanadu-quantum.slack.com/join/shared_invite/zt-nkwn25v9-H4hituCb_PUj4idG0MhSug#/shared-invite/email",
         },
         {
+            "name": "RSS",
             "icon": "bx bx-rss",
             "href": "https://pennylane.ai/blog/",
         },

--- a/pennylane_sphinx_theme/theme.conf
+++ b/pennylane_sphinx_theme/theme.conf
@@ -4,10 +4,11 @@ inherit = xanadu
 [options]
 # Name of the project to appear in the navigation bar.
 navbar_name =
-# Path to an image with the project name and wordmark to appear in the
-# navigation bar. Specifying this option will replace the project name and logo
-# in the navigation bar.
+# Path to an image with the project name and wordmark to appear in the navigation bar.
+# Specifying this option will replace the project name and logo in the navigation bar.
 navbar_wordmark_path = https://assets.cloud.pennylane.ai/docs/pennylane-logo-with-wordmark.svg
+# Alternative text to display in lieu of the wordmark or logo in the navigation bar.
+navbar_logo_alt = PennyLane
 # Path to the project logo to appear in the navigation bar.
 navbar_logo_path =
 # Colour of the auto-generated Xanadu (X) logo (available at ``_static/xanadu_logo.svg``).

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 sphinx==4.5.0
 pillow==10.0.1
 sphinx-gallery==0.10.1
-# TODO: Replace this requirement with a versioned release.
-xanadu-sphinx-theme @ git+https://github.com/XanaduAI/xanadu-sphinx-theme@sc-46517-accessibility-improvements
+xanadu-sphinx-theme==0.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 sphinx==4.5.0
 pillow==10.0.1
 sphinx-gallery==0.10.1
-xanadu-sphinx-theme==0.4.0
+# TODO: Replace this requirement with a versioned release.
+xanadu-sphinx-theme @ git+https://github.com/XanaduAI/xanadu-sphinx-theme@sc-46517-accessibility-improvements

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("pennylane_sphinx_theme/_version.py") as f:
 
 requirements = [
     "sphinx",
-    "xanadu-sphinx-theme~=0.4.0",
+    "xanadu-sphinx-theme~=0.5.0",
     # The packages below are used to generate thumbnail images.
     "pillow",
     "sphinx-gallery",


### PR DESCRIPTION
**Context:**

A recent [XST PR](https://github.com/XanaduAI/xanadu-sphinx-theme/pull/44) introduced a breaking change to the theme configuration.

**Description of the Change:**

This PR upgrades the XST version to v0.5.0 and patches any breaking changes. It also adds a **Discord** link to the footer.

**Benefits:**

* See the [v0.5.0](https://github.com/XanaduAI/xanadu-sphinx-theme/releases/tag/v0.5.0) release notes of the XST.

**Possible Drawbacks:**

None.

**Related GitHub Issues:**

None.

---

**Preview:** https://xanaduai-pennylane--40.com.readthedocs.build/projects/sphinx-theme/en/40/