### PR TITLE
Update Discord link

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,10 +1,17 @@
-## Release 0.6.0 (development release)
+## Release 0.5.1 (current release)
+
+### Bug Fixes
+
+* Fixed the Discord link in the footer.
+  [(#43)](https://github.com/PennyLaneAI/pennylane-sphinx-theme/pull/43)
 
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
 
-## Release 0.5.0 (current release)
+[Mikhail Andrenkov](https://github.com/Mandrenkov).
+
+## Release 0.5.0
 
 ### Improvements
 

--- a/pennylane_sphinx_theme/_version.py
+++ b/pennylane_sphinx_theme/_version.py
@@ -3,4 +3,4 @@ This module specifies the PennyLane Sphinx Theme version with https://semver.org
 using the following format: <major>.<minor>.<patch>[-<pre-release>].
 """
 
-__version__ = "0.6.0-dev"
+__version__ = "0.5.1"

--- a/pennylane_sphinx_theme/footer.py
+++ b/pennylane_sphinx_theme/footer.py
@@ -150,7 +150,7 @@ FOOTER = {
         {
             "name": "Discord",
             "icon": "bx bxl-discord",
-            "href": "https://discord.gg/gnySM3nrN3",
+            "href": "https://discord.com/invite/gnySM3nrN3",
         },
         {
             "name": "LinkedIn",

--- a/pennylane_sphinx_theme/footer.py
+++ b/pennylane_sphinx_theme/footer.py
@@ -150,7 +150,7 @@ FOOTER = {
         {
             "name": "Discord",
             "icon": "bx bxl-discord",
-            "href": "https://discord.com/invite/paYuHUA5hE",
+            "href": "https://discord.gg/gnySM3nrN3",
         },
         {
             "name": "LinkedIn",


### PR DESCRIPTION
**Context:**

The current Discord link in the footer is incorrect.

**Description of the Change:**

* Updated the default Discord link to the following URL: https://discord.com/invite/gnySM3nrN3.
* Bumped the PST version to v0.5.1.

**Benefits:**

* The Discord link matches the main PennyLane website.

**Possible Drawbacks:**

None.

**Related GitHub Issues:**

None.