### PR TITLE
Improve compatibility with PennyLane plugins

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,10 +1,17 @@
-## Release 0.6.0 (development release)
+## Release 0.5.2 (current release)
+
+### Bug Fixes
+
+* Removed version constraints from `docutils` in `setup.py`.
+  [(#45)](https://github.com/PennyLaneAI/pennylane-sphinx-theme/pull/45)
 
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
 
-## Release 0.5.1 (current release)
+[Mikhail Andrenkov](https://github.com/Mandrenkov).
+
+## Release 0.5.1
 
 ### Bug Fixes
 

--- a/pennylane_sphinx_theme/_version.py
+++ b/pennylane_sphinx_theme/_version.py
@@ -3,4 +3,4 @@ This module specifies the PennyLane Sphinx Theme version with https://semver.org
 using the following format: <major>.<minor>.<patch>[-<pre-release>].
 """
 
-__version__ = "0.6.0-dev"
+__version__ = "0.5.2"

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ requirements = [
     # The packages below are used to generate thumbnail images.
     "pillow",
     "sphinx-gallery",
-    "docutils<0.18",
+    "docutils",
 ]
 
 info = {


### PR DESCRIPTION
**Context:**

The `docutils<0.18` requirement in `setup.py` is preventing some PennyLane plugins from using the latest version of the PennyLane Sphinx Theme.

**Description of the Change:**

* Removed the version constraint from `docutils` in `setup.py`.
* Bumped the version to `0.5.2`.

**Benefits:**

* PennyLane plugins can use the latest version of the PST with any `docutils` version.

**Possible Drawbacks:**

None.

**Related GitHub Issues:**

* This is possible due to the resolution of https://github.com/readthedocs/readthedocs.org/issues/9752.