### PR TITLE
Fix "Demos" links

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,10 +1,17 @@
-## Release 0.6.0 (development release)
+## Release 0.5.3 (current release)
+
+### Bug Fixes
+
+* Fixed the 'Demos' link in the navbar.
+  [(#47)](https://github.com/PennyLaneAI/pennylane-sphinx-theme/pull/47)
 
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
 
-## Release 0.5.2 (current release)
+[Mikhail Andrenkov](https://github.com/Mandrenkov).
+
+## Release 0.5.2
 
 ### Bug Fixes
 

--- a/pennylane_sphinx_theme/_version.py
+++ b/pennylane_sphinx_theme/_version.py
@@ -3,4 +3,4 @@ This module specifies the PennyLane Sphinx Theme version with https://semver.org
 using the following format: <major>.<minor>.<patch>[-<pre-release>].
 """
 
-__version__ = "0.6.0-dev"
+__version__ = "0.5.3"

--- a/pennylane_sphinx_theme/footer.py
+++ b/pennylane_sphinx_theme/footer.py
@@ -37,7 +37,7 @@ FOOTER = {
             "links": [
                 {
                     "name": "Demos",
-                    "href": "https://pennylane.ai/qml/demonstrations",
+                    "href": "https://pennylane.ai/qml/demonstrations/",
                 },
                 {
                     "name": "Datasets",
@@ -90,7 +90,7 @@ FOOTER = {
                 },
                 {
                     "name": "Demos",
-                    "href": "https://pennylane.ai/qml/demonstrations",
+                    "href": "https://pennylane.ai/qml/demonstrations/",
                 },
                 {
                     "name": "Glossary",
@@ -119,7 +119,7 @@ FOOTER = {
                 },
                 {
                     "name": "Demos",
-                    "href": "https://pennylane.ai/qml/demonstrations",
+                    "href": "https://pennylane.ai/qml/demonstrations/",
                 },
                 {
                     "name": "Performance",

--- a/pennylane_sphinx_theme/navbar.py
+++ b/pennylane_sphinx_theme/navbar.py
@@ -9,7 +9,7 @@ NAVBAR_LEFT = [
         "dropdown": [
             {
                 "name": "Demos",
-                "href": "https://pennylane.ai/qml/",
+                "href": "https://pennylane.ai/qml/demonstrations/",
             },
             {
                 "name": "Codebook",


### PR DESCRIPTION
**Context:**

The "Demos" link in the navbar is missing the `demonstrations/` suffix relative to the main PennyLane website.

**Description of the Change:**

* Changed the "Demos" link in the navbar from [`/qml/`](https://pennylane.ai/qml/) to [`/qml/demonstrations/`](  https://pennylane.ai/qml/demonstrations).
* Added a trailing `/` to the "Demos" links in the footer for consistency.
* Bumped the version to `0.5.3`.

**Benefits:**

* The navbar in the main PennyLane website is more consistent with the PennyLane Sphinx Theme.

**Possible Drawbacks:**

None.

**Related GitHub Issues:**

None.

---

**Preview:** https://xanaduai-pennylane--47.com.readthedocs.build/projects/sphinx-theme/en/47/