### PR TITLE
SC 52474 | Update NavBar in PennyLane Sphinx theme

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,8 +1,15 @@
-## Release 0.6.0 (development release)
+## Release 0.5.4 (development release)
+
+### Improvements
+
+* Added a link to navbar to the PennyLane Get Involved page.
+  [(#49)](https://github.com/PennyLaneAI/pennylane-sphinx-theme/pull/49)
 
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
+
+[Alan Martin](https://github.com/alan-emartin).
 
 ## Release 0.5.3 (current release)
 

--- a/pennylane_sphinx_theme/navbar.py
+++ b/pennylane_sphinx_theme/navbar.py
@@ -66,6 +66,10 @@ NAVBAR_LEFT = [
         ],
     },
     {
+        "name": "Get involved",
+        "href": "https://pennylane.ai/get-involved/",
+    },
+    {
         "name": "Datasets",
         "href": "https://pennylane.ai/datasets/",
     },


### PR DESCRIPTION
**Context:**

- Link to new "Get Involved" page (unreleased).
- Flagged DO NOT MERGE - merge into productions is blocked util release of related content.

**Description of the Change:**
- Added a new item to the `navbar.py` file for "Get involved" page.

**Benefits:**
Linking to "Get involved" page from docs to main site.

**Possible Drawbacks:**
n/a

**Related GitHub Issues:**
n/a
