### PR TITLE
Sc 57065 add features page link in sphinx navbar

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### Improvements
 
 * Added a link to navbar and footer for the PennyLane Features page.
-  [(#49)](https://github.com/PennyLaneAI/pennylane-sphinx-theme/pull/49)
+  [(#54)]([https://github.com/PennyLaneAI/pennylane-sphinx-theme/pull/49](https://github.com/PennyLaneAI/pennylane-sphinx-theme/pull/54))
 
 ### Contributors
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### Improvements
 
 * Added a link to navbar and footer for the PennyLane Features page.
-  [(#54)]([https://github.com/PennyLaneAI/pennylane-sphinx-theme/pull/49](https://github.com/PennyLaneAI/pennylane-sphinx-theme/pull/54))
+  [(#54)](https://github.com/PennyLaneAI/pennylane-sphinx-theme/pull/49)
 
 ### Contributors
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,8 +1,15 @@
 ## Release 0.6.0 (development release)
 
+### Improvements
+
+* Added a link to navbar and footer for the PennyLane Features page.
+  [(#49)](https://github.com/PennyLaneAI/pennylane-sphinx-theme/pull/49)
+
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
+
+[Lucas Silbernagel](https://github.com/LucasSilbernagel).
 
 ## Release 0.5.4 (current release)
 

--- a/pennylane_sphinx_theme/footer.py
+++ b/pennylane_sphinx_theme/footer.py
@@ -36,6 +36,10 @@ FOOTER = {
             "title": "For researchers",
             "links": [
                 {
+                    "name": "Features",
+                    "href": "https://pennylane.ai/features/",
+                },
+                {
                     "name": "Demos",
                     "href": "https://pennylane.ai/qml/demonstrations/",
                 },
@@ -101,6 +105,10 @@ FOOTER = {
         {
             "title": "For developers",
             "links": [
+                {
+                    "name": "Features",
+                    "href": "https://pennylane.ai/features/",
+                },
                 {
                     "name": "Documentation",
                     "href": "https://docs.pennylane.ai/",

--- a/pennylane_sphinx_theme/navbar.py
+++ b/pennylane_sphinx_theme/navbar.py
@@ -29,6 +29,10 @@ NAVBAR_LEFT = [
                 "href": "https://pennylane.ai/qml/glossary/",
             },
             {
+                "name": "Features",
+                "href": "https://pennylane.ai/features/",
+            },
+            {
                 "name": "Education",
                 "href": "https://pennylane.ai/education/",
             },


### PR DESCRIPTION
**Context:**

- Link to new "Features" page (unreleased).
- Flagged DO NOT MERGE - merge into production is blocked until release of related content.

**Description of the Change:**
- Added a new item to the `navbar.py` and `footer.py` files for "Features" page.

**Benefits:**
Linking to "Features" page from docs to main site.

**Possible Drawbacks:**
n/a

**Related GitHub Issues:**
n/a
