### PR TITLE
SC62463 | Update codebook URLs - Merge May 13th

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -4,7 +4,20 @@
 
 This release contains contributions from (in alphabetical order):
 
-## Release 0.5.5 (current release)
+## Release 0.5.6 (current release)
+
+### Improvements
+
+* Update the Codebook links in the navbar and footer to use the new Codebook URLs.
+  [(#60)](https://github.com/PennyLaneAI/pennylane-sphinx-theme/pull/60)
+
+### Contributors
+
+This release contains contributions from (in alphabetical order):
+
+[Andrew Gardhouse](https://github.com/AndrewGardhouse).
+
+## Release 0.5.5
 
 ### Improvements
 

--- a/pennylane_sphinx_theme/footer.py
+++ b/pennylane_sphinx_theme/footer.py
@@ -78,7 +78,7 @@ FOOTER = {
                 },
                 {
                     "name": "Codebook",
-                    "href": "https://codebook.xanadu.ai/",
+                    "href": "https://pennylane.ai/codebook/",
                 },
                 {
                     "name": "Education",

--- a/pennylane_sphinx_theme/navbar.py
+++ b/pennylane_sphinx_theme/navbar.py
@@ -13,7 +13,7 @@ NAVBAR_LEFT = [
             },
             {
                 "name": "Codebook",
-                "href": "https://codebook.xanadu.ai/",
+                "href": "https://pennylane.ai/codebook/",
                 "external": True,
             },
             {


### PR DESCRIPTION
**Context:**
https://app.shortcut.com/xanaduai/story/62052/existing-codebook-links-in-pennylane-and-xanadu-websites-are-replace-with-new-codebook-url

**Description of the Change:**
- Codebook URLs are updated from https://codebook.xanadu.ai/ to https://pennylane.ai/codebook/

**Benefits:**
- Users visit the new codebook

**Possible Drawbacks:**
None

**Related GitHub Issues:**
None