### PR TITLE
Codebook URL is not external

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -4,7 +4,21 @@
 
 This release contains contributions from (in alphabetical order):
 
-## Release 0.5.6 (current release)
+## Release 0.5.7 (current release)
+
+### Improvements
+
+* Update the Codebook link in the navbar to not be treated as external.
+  <!-- [(#60)](https://github.com/PennyLaneAI/pennylane-sphinx-theme/pull/60) -->
+
+### Contributors
+
+This release contains contributions from (in alphabetical order):
+
+[Andrew Gardhouse](https://github.com/AndrewGardhouse).
+
+
+## Release 0.5.6
 
 ### Improvements
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -9,7 +9,7 @@ This release contains contributions from (in alphabetical order):
 ### Improvements
 
 * Update the Codebook link in the navbar to not be treated as external.
-  <!-- [(#60)](https://github.com/PennyLaneAI/pennylane-sphinx-theme/pull/60) -->
+  [(#63)](https://github.com/PennyLaneAI/pennylane-sphinx-theme/pull/63)
 
 ### Contributors
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,9 +1,3 @@
-## Release 0.6.0 (development release)
-
-### Contributors
-
-This release contains contributions from (in alphabetical order):
-
 ## Release 0.5.7 (current release)
 
 ### Improvements
@@ -16,7 +10,6 @@ This release contains contributions from (in alphabetical order):
 This release contains contributions from (in alphabetical order):
 
 [Andrew Gardhouse](https://github.com/AndrewGardhouse).
-
 
 ## Release 0.5.6
 

--- a/pennylane_sphinx_theme/_version.py
+++ b/pennylane_sphinx_theme/_version.py
@@ -3,4 +3,4 @@ This module specifies the PennyLane Sphinx Theme version with https://semver.org
 using the following format: <major>.<minor>.<patch>[-<pre-release>].
 """
 
-__version__ = "0.6.0-dev"
+__version__ = "0.5.7"

--- a/pennylane_sphinx_theme/navbar.py
+++ b/pennylane_sphinx_theme/navbar.py
@@ -14,7 +14,6 @@ NAVBAR_LEFT = [
             {
                 "name": "Codebook",
                 "href": "https://pennylane.ai/codebook/",
-                "external": True,
             },
             {
                 "name": "Challenges",


### PR DESCRIPTION
**Context:**
https://xanaduhq.slack.com/archives/C04LHMKL3L6/p1715365605983909

**Description of the Change:**
- External link icon is removed from Codebook link in the navbar

**Benefits:**
- Codebook link is correctly shown as a link to a pennylane website page

**Possible Drawbacks:**
None

**Related GitHub Issues:**
None