### PR TITLE
sc-72333-remove-rss-symbol-link-in-the-pennylane-ai-docs

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### Improvements
 
 * Removed the rss feed icon from the footer
-  [(#63)](https://github.com/PennyLaneAI/pennylane-sphinx-theme/pull/65)
+  [(#65)](https://github.com/PennyLaneAI/pennylane-sphinx-theme/pull/65)
 
 ### Contributors
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Improvements
 
-* Removed the rss feed icon from the footer
+* Removed the RSS feed icon from the footer.
   [(#65)](https://github.com/PennyLaneAI/pennylane-sphinx-theme/pull/65)
 
 ### Contributors

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,10 +1,17 @@
-## Release 0.6.0 (development release)
+## Release 0.5.8 (current release)
+
+### Improvements
+
+* Removed the rss feed icon from the footer
+  [(#63)](https://github.com/PennyLaneAI/pennylane-sphinx-theme/pull/65)
 
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
 
-## Release 0.5.7 (current release)
+[Ashish Kanwar Singh](https://github.com/ashishks0522).
+
+## Release 0.5.7
 
 ### Improvements
 

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -11,3 +11,4 @@ sphinxcontrib-serializinghtml==1.1.5
 sphinx-copybutton
 sphinx-gallery==0.10.1
 xanadu-sphinx-theme==0.5.0
+numpy==1.26.4

--- a/pennylane_sphinx_theme/_version.py
+++ b/pennylane_sphinx_theme/_version.py
@@ -3,4 +3,4 @@ This module specifies the PennyLane Sphinx Theme version with https://semver.org
 using the following format: <major>.<minor>.<patch>[-<pre-release>].
 """
 
-__version__ = "0.6.0-dev"
+__version__ = "0.5.8"

--- a/pennylane_sphinx_theme/footer.py
+++ b/pennylane_sphinx_theme/footer.py
@@ -180,11 +180,6 @@ FOOTER = {
             "icon": "bx bxl-slack",
             "href": "https://xanadu-quantum.slack.com/join/shared_invite/zt-nkwn25v9-H4hituCb_PUj4idG0MhSug#/shared-invite/email",
         },
-        {
-            "name": "RSS",
-            "icon": "bx bx-rss",
-            "href": "https://pennylane.ai/blog/",
-        },
     ],
     "footer_taglines": [
         {

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ sphinx==4.5.0
 pillow==10.3.0
 sphinx-gallery==0.10.1
 xanadu-sphinx-theme==0.5.0
+numpy==1.26.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@ sphinx==4.5.0
 pillow==10.3.0
 sphinx-gallery==0.10.1
 xanadu-sphinx-theme==0.5.0
-numpy==1.26.4


### PR DESCRIPTION
## Changes
- [sc-72333-remove-rss-symbol-link-in-the-pennylane-ai](https://app.shortcut.com/xanaduai/story/72333/remove-rss-symbol-link-in-the-pennylane-ai-footer)


## Related PR
- https://github.com/XanaduAI/pennylane.ai-react/pull/1759