### PR TITLE
Redirect searches to PennyLane.ai

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Improvements
 
-* Bumped the Xanadu Sphinx Theme version to `0.6.0`.
+* Bumped the Xanadu Sphinx Theme version to `0.6.1`.
   [(#67)](https://github.com/PennyLaneAI/pennylane-sphinx-theme/pull/67)
 
 ### Contributors

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,10 +1,17 @@
-## Release 0.6.0 (development release)
+## Release 0.6.0 (current release)
+
+### Improvements
+
+* Bumped the Xanadu Sphinx Theme version to `0.6.0`.
+  [(#67)](https://github.com/PennyLaneAI/pennylane-sphinx-theme/pull/67)
 
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
 
-## Release 0.5.8 (current release)
+[Mikhail Andrenkov](https://github.com/Mandrenkov).
+
+## Release 0.5.8
 
 ### Improvements
 

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,6 +1,7 @@
 importlib-resources==5.12.0
 m2r2
 matplotlib==3.5.3
+numpy==1.26.4
 pillow==10.3.0
 sphinx==4.5.0
 sphinxcontrib-applehelp==1.0.4
@@ -10,5 +11,5 @@ sphinxcontrib-htmlhelp==2.0.1
 sphinxcontrib-serializinghtml==1.1.5
 sphinx-copybutton
 sphinx-gallery==0.10.1
-xanadu-sphinx-theme==0.5.0
-numpy==1.26.4
+# TODO: Replace the following line with 'xanadu-sphinx-theme==0.6.0'.
+xanadu-sphinx-theme @ git+https://github.com/XanaduAI/xanadu-sphinx-theme@sc-75207-pennylane-ai-search-redirect

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -11,5 +11,4 @@ sphinxcontrib-htmlhelp==2.0.1
 sphinxcontrib-serializinghtml==1.1.5
 sphinx-copybutton
 sphinx-gallery==0.10.1
-# TODO: Replace the following line with 'xanadu-sphinx-theme==0.6.0'.
-xanadu-sphinx-theme @ git+https://github.com/XanaduAI/xanadu-sphinx-theme@sc-75207-pennylane-ai-search-redirect
+xanadu-sphinx-theme==0.6.1

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -11,4 +11,4 @@ sphinxcontrib-htmlhelp==2.0.1
 sphinxcontrib-serializinghtml==1.1.5
 sphinx-copybutton
 sphinx-gallery==0.10.1
-xanadu-sphinx-theme==0.6.1
+xanadu-sphinx-theme==0.6.2

--- a/pennylane_sphinx_theme/_version.py
+++ b/pennylane_sphinx_theme/_version.py
@@ -3,4 +3,4 @@ This module specifies the PennyLane Sphinx Theme version with https://semver.org
 using the following format: <major>.<minor>.<patch>[-<pre-release>].
 """
 
-__version__ = "0.6.0-dev"
+__version__ = "0.6.0"

--- a/pennylane_sphinx_theme/theme.conf
+++ b/pennylane_sphinx_theme/theme.conf
@@ -60,6 +60,9 @@ google_analytics_tracking_id =
 # List of extra copyright notices to place in the footer.
 extra_copyrights =
 
+# Whether to redirect searches to https://pennylane.ai/search.
+search_on_pennylane_ai = True
+
 # Title, icon, link, and description of the About section in the footer
 footer_about =
 # Column links to display in the footer

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 sphinx==4.5.0
 pillow==10.3.0
 sphinx-gallery==0.10.1
-# TODO: Replace the following line with 'xanadu-sphinx-theme==0.6.0'.
-xanadu-sphinx-theme @ git+https://github.com/XanaduAI/xanadu-sphinx-theme@sc-75207-pennylane-ai-search-redirect
+xanadu-sphinx-theme==0.6.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 sphinx==4.5.0
 pillow==10.3.0
 sphinx-gallery==0.10.1
-xanadu-sphinx-theme==0.5.0
+# TODO: Replace the following line with 'xanadu-sphinx-theme==0.6.0'.
+xanadu-sphinx-theme @ git+https://github.com/XanaduAI/xanadu-sphinx-theme@sc-75207-pennylane-ai-search-redirect

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 sphinx==4.5.0
 pillow==10.3.0
 sphinx-gallery==0.10.1
-xanadu-sphinx-theme==0.6.1
+xanadu-sphinx-theme==0.6.2

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 with open("pennylane_sphinx_theme/_version.py") as f:
     version = f.readlines()[-1].split()[-1].strip("\"'")
@@ -6,7 +6,7 @@ with open("pennylane_sphinx_theme/_version.py") as f:
 
 requirements = [
     "sphinx",
-    "xanadu-sphinx-theme~=0.5.0",
+    "xanadu-sphinx-theme~=0.6.0",
     # The packages below are used to generate thumbnail images.
     "pillow",
     "sphinx-gallery",
@@ -45,6 +45,8 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: Documentation",
     "Topic :: Documentation :: Sphinx",
     "Topic :: Software Development",

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("pennylane_sphinx_theme/_version.py") as f:
 
 requirements = [
     "sphinx",
-    "xanadu-sphinx-theme~=0.6.0",
+    "xanadu-sphinx-theme~=0.6.1",
     # The packages below are used to generate thumbnail images.
     "pillow",
     "sphinx-gallery",


### PR DESCRIPTION
**Context:**

Search in Sphinx is, both functionally and aesthetically, lacking. This PR upgrades the version of the [Xanadu Sphinx Theme](https://github.com/XanaduAI/xanadu-sphinx-theme) to `0.6.0` which includes a theme option for redirecting users from `search.html` to https://pennylane.ai/search.

**Description of the Change:**

1. Integrated https://github.com/XanaduAI/xanadu-sphinx-theme/pull/47.

**Benefits:**

1. PennyLane Docs users have easier access to a better search experience.

**Possible Drawbacks:**

_None._

**Related GitHub Issues:**

_None._

---

**Verification:**

See https://xanaduai-pennylane--67.com.readthedocs.build/projects/sphinx-theme/en/67/.

**Merge Checklist:**
* [X] https://github.com/XanaduAI/xanadu-sphinx-theme/pull/47 is merged.
* [X] References to XST GitHub repository branches and replaced with semantic versions.
* [X] PennyLane Docs are surfaced in PennyLane.ai search results.