### PR TITLE
sc-76288-sc-76287-update-navbar-and-footer-links-to-focus-on-researchers

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Improvements
 
-* Update footer contents - Add Research page link and change `Education` label to `Teach`
+* Update navbar & footer contents to be more researcher focused.
   [(#68)](https://github.com/PennyLaneAI/pennylane-sphinx-theme/pull/68)
 
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 This release contains contributions from (in alphabetical order):
 
+[Ashish Kanwar Singh](https://github.com/ashishks0522).
+
 ## Release 0.5.8 (current release)
 
 ### Improvements

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,4 +1,10 @@
-## Release 0.6.0 (development release)
+## Release 0.5.9 (development release)
+
+### Improvements
+
+* Update footer contents - Add Research page link and change `Education` label to `Teach`
+  [(#68)](https://github.com/PennyLaneAI/pennylane-sphinx-theme/pull/68)
+
 
 ### Contributors
 

--- a/pennylane_sphinx_theme/footer.py
+++ b/pennylane_sphinx_theme/footer.py
@@ -36,24 +36,28 @@ FOOTER = {
             "title": "For researchers",
             "links": [
                 {
+                    "name": "Research",
+                    "href": "https://pennylane.ai/research",
+                },
+                {
                     "name": "Features",
-                    "href": "https://pennylane.ai/features/",
+                    "href": "https://pennylane.ai/features",
                 },
                 {
                     "name": "Demos",
-                    "href": "https://pennylane.ai/qml/demonstrations/",
+                    "href": "https://pennylane.ai/qml/demonstrations",
                 },
                 {
                     "name": "Datasets",
-                    "href": "https://pennylane.ai/datasets/",
+                    "href": "https://pennylane.ai/datasets",
                 },
                 {
                     "name": "Performance",
-                    "href": "https://pennylane.ai/performance/",
+                    "href": "https://pennylane.ai/performance",
                 },
                 {
                     "name": "Learn",
-                    "href": "https://pennylane.ai/qml/",
+                    "href": "https://pennylane.ai/qml",
                 },
                 {
                     "name": "Videos",
@@ -64,8 +68,8 @@ FOOTER = {
                     "href": "https://docs.pennylane.ai/",
                 },
                 {
-                    "name": "Education",
-                    "href": "https://pennylane.ai/education/",
+                    "name": "Teach",
+                    "href": "https://pennylane.ai/education",
                 },
             ],
         },
@@ -74,15 +78,15 @@ FOOTER = {
             "links": [
                 {
                     "name": "Learn",
-                    "href": "https://pennylane.ai/qml/",
+                    "href": "https://pennylane.ai/qml",
                 },
                 {
                     "name": "Codebook",
-                    "href": "https://pennylane.ai/codebook/",
+                    "href": "https://pennylane.ai/codebook",
                 },
                 {
-                    "name": "Education",
-                    "href": "https://pennylane.ai/education/",
+                    "name": "Teach",
+                    "href": "https://pennylane.ai/education",
                 },
                 {
                     "name": "Videos",
@@ -90,15 +94,15 @@ FOOTER = {
                 },
                 {
                     "name": "Challenges",
-                    "href": "https://pennylane.ai/challenges/",
+                    "href": "https://pennylane.ai/challenges",
                 },
                 {
                     "name": "Demos",
-                    "href": "https://pennylane.ai/qml/demonstrations/",
+                    "href": "https://pennylane.ai/qml/demonstrations",
                 },
                 {
                     "name": "Glossary",
-                    "href": "https://pennylane.ai/qml/glossary/",
+                    "href": "https://pennylane.ai/qml/glossary",
                 },
             ],
         },
@@ -107,11 +111,11 @@ FOOTER = {
             "links": [
                 {
                     "name": "Features",
-                    "href": "https://pennylane.ai/features/",
+                    "href": "https://pennylane.ai/features",
                 },
                 {
                     "name": "Documentation",
-                    "href": "https://docs.pennylane.ai/",
+                    "href": "https://docs.pennylane.ai",
                 },
                 {
                     "name": "API",
@@ -123,19 +127,19 @@ FOOTER = {
                 },
                 {
                     "name": "Datasets",
-                    "href": "https://pennylane.ai/datasets/",
+                    "href": "https://pennylane.ai/datasets",
                 },
                 {
                     "name": "Demos",
-                    "href": "https://pennylane.ai/qml/demonstrations/",
+                    "href": "https://pennylane.ai/qml/demonstrations",
                 },
                 {
                     "name": "Performance",
-                    "href": "https://pennylane.ai/performance/",
+                    "href": "https://pennylane.ai/performance",
                 },
                 {
                     "name": "Devices",
-                    "href": "https://pennylane.ai/plugins/",
+                    "href": "https://pennylane.ai/plugins",
                 },
                 {
                     "name": "Compilation",

--- a/pennylane_sphinx_theme/navbar.py
+++ b/pennylane_sphinx_theme/navbar.py
@@ -126,6 +126,5 @@ NAVBAR_RIGHT = [
     {
         "name": "Install",
         "href": "https://pennylane.ai/install",
-
     },
 ]

--- a/pennylane_sphinx_theme/navbar.py
+++ b/pennylane_sphinx_theme/navbar.py
@@ -66,7 +66,7 @@ NAVBAR_LEFT = [
         "dropdown": [
             {
                 "name": "How-to demos",
-                "href": "https://pennylane.ai/qml/demonstrations#how-to",
+                "href": "https://pennylane.ai/search/?contentType=DEMO&categories=how-to&sort=publication_date",
             },
             {
                 "name": "Development guide",

--- a/pennylane_sphinx_theme/navbar.py
+++ b/pennylane_sphinx_theme/navbar.py
@@ -89,7 +89,7 @@ NAVBAR_LEFT = [
     },
     {
         "name": "Ecosystem",
-        "href": "/get-involved",
+        "href": "https://pennylane.ai/get-involved",
         "dropdown": [
             {
                 "name": "Blog",

--- a/pennylane_sphinx_theme/navbar.py
+++ b/pennylane_sphinx_theme/navbar.py
@@ -125,6 +125,7 @@ NAVBAR_LEFT = [
 NAVBAR_RIGHT = [
     {
         "name": "Install",
-        "href": "https://pennylane.ai/instal",
+        "href": "https://pennylane.ai/install",
+
     },
 ]

--- a/pennylane_sphinx_theme/navbar.py
+++ b/pennylane_sphinx_theme/navbar.py
@@ -4,58 +4,108 @@ This module contains the common PennyLane navigation bar data.
 
 NAVBAR_LEFT = [
     {
-        "name": "Learn",
-        "href": "https://pennylane.ai/qml/",
+        "name": "Why PennyLane",
+        "href": "https://pennylane.ai/research",
+        "dropdown": [
+            { 
+                "name": "Features", 
+                "href": "https://pennylane.ai/features" 
+            },
+            { 
+                "name": "Demos", 
+                "href": "https://pennylane.ai/qml/demonstrations" 
+            },
+            { 
+                "name": "Datasets", 
+                "href": "https://pennylane.ai/datasets" 
+            },
+            { 
+                "name": "Performance", 
+                "href": "https://pennylane.ai/performance" 
+            },
+            { 
+                "name": "Devices", 
+                "href": "https://pennylane.ai/plugins" 
+            },
+            { 
+                "name": "Teach", 
+                "href": "https://pennylane.ai/education" 
+            },
+        ],
+    },
+    {
+        "name": "Getting Started",
+        "href": "https://pennylane.ai/qml",
         "dropdown": [
             {
+                "name": "Install",
+                "href": "https://pennylane.ai/install",
+            },
+            {
                 "name": "Demos",
-                "href": "https://pennylane.ai/qml/demonstrations/",
+                "href": "https://pennylane.ai/qml/demonstrations",
             },
             {
                 "name": "Codebook",
-                "href": "https://pennylane.ai/codebook/",
+                "href": "https://pennylane.ai/codebook",
             },
             {
                 "name": "Challenges",
-                "href": "https://pennylane.ai/challenges/",
+                "href": "https://pennylane.ai/challenges",
             },
             {
-                "name": "Videos",
-                "href": "https://pennylane.ai/qml/videos/",
-            },
-            {
-                "name": "Glossary",
-                "href": "https://pennylane.ai/qml/glossary/",
-            },
-            {
-                "name": "Features",
-                "href": "https://pennylane.ai/features/",
-            },
-            {
-                "name": "Education",
-                "href": "https://pennylane.ai/education/",
-            },
-            {
-                "name": "Performance",
-                "href": "https://pennylane.ai/performance/",
-            },
-            {
-                "name": "FAQ",
-                "href": "https://pennylane.ai/faq/",
+                "name": "Support",
+                "href": "https://discuss.pennylane.ai/",
+                "external": True,
             },
         ],
     },
     {
         "name": "Documentation",
-        "href": "https://docs.pennylane.ai",
+        "href": "https://docs.pennylane.ai/en/stable/",
         "dropdown": [
+            {
+                "name": "How-to demos",
+                "href": "https://pennylane.ai/qml/demonstrations#how-to",
+            },
+            {
+                "name": "Development guide",
+                "href": "https://docs.pennylane.ai/en/stable/development/guide.html",
+            },
+            {
+                "name": "Catalyst",
+                "href": "https://docs.pennylane.ai/projects/catalyst/en/stable/",
+            },
             {
                 "name": "API",
                 "href": "https://docs.pennylane.ai/en/stable/code/qml.html",
             },
             {
-                "name": "Devices",
-                "href": "https://pennylane.ai/plugins/",
+                "name": "GitHub",
+                "href": "https://github.com/PennyLaneAI/pennylane",
+                "external": True,
+            },
+        ],
+    },
+    {
+        "name": "Ecosystem",
+        "href": "/get-involved",
+        "dropdown": [
+            {
+                "name": "Blog",
+                "href": "https://pennylane.ai/blog/?page=1",
+            },
+            {
+                "name": "Glossary",
+                "href": "https://pennylane.ai/qml/glossary",
+            },
+            {
+                "name": "Videos",
+                "href": "https://pennylane.ai/qml/videos",
+            },
+            {
+                "name": "FAQs",
+                "href": "https://pennylane.ai/faq",
             },
             {
                 "name": "GitHub",
@@ -63,39 +113,18 @@ NAVBAR_LEFT = [
                 "external": True,
             },
             {
-                "name": "Catalyst",
-                "href": "https://docs.pennylane.ai/projects/catalyst/",
+                "name": "Support",
+                "href": "https://discuss.pennylane.ai/",
+                "external": True,
             },
         ],
-    },
-    {
-        "name": "Get involved",
-        "href": "https://pennylane.ai/get-involved/",
-    },
-    {
-        "name": "Datasets",
-        "href": "https://pennylane.ai/datasets/",
-    },
-    {
-        "name": "Blog",
-        "href": "https://pennylane.ai/blog/",
-    },
-    {
-        "name": "Support",
-        "href": "https://discuss.pennylane.ai",
-        "external": True,
     },
 ]
 
 
 NAVBAR_RIGHT = [
     {
-        "name": "GitHub",
-        "href": "https://github.com/PennyLaneAI/pennylane",
-        "icon": "bx bxl-github",
-    },
-    {
         "name": "Install",
-        "href": "https://pennylane.ai/install",
+        "href": "https://pennylane.ai/instal",
     },
 ]

--- a/pennylane_sphinx_theme/navbar.py
+++ b/pennylane_sphinx_theme/navbar.py
@@ -7,29 +7,29 @@ NAVBAR_LEFT = [
         "name": "Why PennyLane",
         "href": "https://pennylane.ai/research",
         "dropdown": [
-            { 
-                "name": "Features", 
-                "href": "https://pennylane.ai/features" 
+            {
+                "name": "Features",
+                "href": "https://pennylane.ai/features",
             },
-            { 
-                "name": "Demos", 
-                "href": "https://pennylane.ai/qml/demonstrations" 
+            {
+                "name": "Demos",
+                "href": "https://pennylane.ai/qml/demonstrations",
             },
-            { 
-                "name": "Datasets", 
-                "href": "https://pennylane.ai/datasets" 
+            {
+                "name": "Datasets",
+                "href": "https://pennylane.ai/datasets",
             },
-            { 
-                "name": "Performance", 
-                "href": "https://pennylane.ai/performance" 
+            {
+                "name": "Performance",
+                "href": "https://pennylane.ai/performance",
             },
-            { 
-                "name": "Devices", 
-                "href": "https://pennylane.ai/plugins" 
+            {
+                "name": "Devices",
+                "href": "https://pennylane.ai/plugins",
             },
-            { 
-                "name": "Teach", 
-                "href": "https://pennylane.ai/education" 
+            {
+                "name": "Teach",
+                "href": "https://pennylane.ai/education",
             },
         ],
     },


### PR DESCRIPTION
## Stories
- [sc-76287-update-navbar-links-in-sphinx](https://app.shortcut.com/xanaduai/story/76287/update-navbar-links-in-sphinx)
- [sc-76288-update-footer-links-to-include-research-page](https://app.shortcut.com/xanaduai/story/76288/update-footer-links-to-include-research-page-in-sphinx)

## Changes
- Updated navbar to be more researcher focused  - similar to https://github.com/XanaduAI/pennylane.ai-react/pull/1829
- Updated footer links to include `Research` page link  - similar to https://github.com/XanaduAI/pennylane.ai-react/pull/1834
- Removed trailing slash from PennyLane website URLs


![Screenshot 2024-11-01 at 1 56 39 PM](https://github.com/user-attachments/assets/5be30b0d-55a6-4911-81d8-18cab67cdd2d)

![Screenshot 2024-11-01 at 3 55 37 PM](https://github.com/user-attachments/assets/bb51a32c-821f-4e39-b8a8-867644c10c6d)
![Screenshot 2024-11-01 at 3 55 33 PM](https://github.com/user-attachments/assets/2e2271e7-66c8-4722-9337-948760c65a57)
![Screenshot 2024-11-01 at 3 55 29 PM](https://github.com/user-attachments/assets/504c211e-d0c5-446c-bc21-670629f84beb)
![Screenshot 2024-11-01 at 3 55 24 PM](https://github.com/user-attachments/assets/ad57c5b5-8943-4e42-a259-51f79ebd3a35)
