### PR TITLE
Enable Command Palette for PennyLane Theme Config

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,6 +1,13 @@
-## Release 0.7.0 (development release)
+## Release 0.7.0
 
 ### Contributors
+
+- [Alan Martin](https://github.com/alan-emartin)
+
+### Features
+
+* Configured and enabled `pennylane-command-palette`.
+  [#77](https://github.com/PennyLaneAI/pennylane-sphinx-theme/pull/77)
 
 This release contains contributions from (in alphabetical order):
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Contributors
 
-- [Alan Martin](https://github.com/alan-emartin)
+* [Alan Martin](https://github.com/alan-emartin)
 
 ### Features
 

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -11,4 +11,4 @@ sphinxcontrib-htmlhelp==2.0.1
 sphinxcontrib-serializinghtml==1.1.5
 sphinx-copybutton
 sphinx-gallery==0.10.1
-xanadu-sphinx-theme @ git+https://github.com/XanaduAI/xanadu-sphinx-theme@sc-77533-search-command-palette-button-is-added-to
+xanadu-sphinx-theme==0.7.0

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -11,4 +11,5 @@ sphinxcontrib-htmlhelp==2.0.1
 sphinxcontrib-serializinghtml==1.1.5
 sphinx-copybutton
 sphinx-gallery==0.10.1
-xanadu-sphinx-theme==0.6.2
+# xanadu-sphinx-theme==0.6.2 -> 0.7.0
+xanadu-sphinx-theme @ git+https://github.com/XanaduAI/xanadu-sphinx-theme@sc-77533-search-command-palette-button-is-added-to

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -11,5 +11,4 @@ sphinxcontrib-htmlhelp==2.0.1
 sphinxcontrib-serializinghtml==1.1.5
 sphinx-copybutton
 sphinx-gallery==0.10.1
-# xanadu-sphinx-theme==0.6.2 -> 0.7.0
 xanadu-sphinx-theme @ git+https://github.com/XanaduAI/xanadu-sphinx-theme@sc-77533-search-command-palette-button-is-added-to

--- a/pennylane_sphinx_theme/theme.conf
+++ b/pennylane_sphinx_theme/theme.conf
@@ -61,6 +61,9 @@ extra_copyrights =
 # Whether to redirect searches to https://pennylane.ai/search.
 search_on_pennylane_ai = True
 
+# Whether to enable the pennylane command palette. 
+command_palette_enabled = True
+
 # Title, icon, link, and description of the About section in the footer
 footer_about =
 # Column links to display in the footer

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,4 @@
 sphinx==4.5.0
 pillow==10.3.0
 sphinx-gallery==0.10.1
-# Update to correct xanadu-sphinx-theme version when testing is
-# xanadu-sphinx-theme==0.6.2 -> 0.7.0
 xanadu-sphinx-theme @ git+https://github.com/XanaduAI/xanadu-sphinx-theme@sc-77533-search-command-palette-button-is-added-to

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 sphinx==4.5.0
 pillow==10.3.0
 sphinx-gallery==0.10.1
-xanadu-sphinx-theme @ git+https://github.com/XanaduAI/xanadu-sphinx-theme@sc-77533-search-command-palette-button-is-added-to
+xanadu-sphinx-theme==0.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
 sphinx==4.5.0
 pillow==10.3.0
 sphinx-gallery==0.10.1
-xanadu-sphinx-theme==0.6.2
+# Update to correct xanadu-sphinx-theme version when testing is
+# xanadu-sphinx-theme==0.6.2 -> 0.7.0
+xanadu-sphinx-theme @ git+https://github.com/XanaduAI/xanadu-sphinx-theme@sc-77533-search-command-palette-button-is-added-to

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("pennylane_sphinx_theme/_version.py") as f:
 
 requirements = [
     "sphinx",
-    "xanadu-sphinx-theme~=0.6.1",
+    "xanadu-sphinx-theme~=0.7.0-dev",
     # The packages below are used to generate thumbnail images.
     "pillow",
     "sphinx-gallery",

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("pennylane_sphinx_theme/_version.py") as f:
 
 requirements = [
     "sphinx",
-    "xanadu-sphinx-theme~=0.7.0-dev",
+    "xanadu-sphinx-theme~=0.7.0",
     # The packages below are used to generate thumbnail images.
     "pillow",
     "sphinx-gallery",


### PR DESCRIPTION
**Context:**
- Embeds `pennylane-command-palette`

**Description of the Change:**
- Enabled the `pennylane-command-palette` by configuring the `command_palette_enabled` in the sphinx `theme.conf`
- Blocked by related PR from `xanadu-sphinx-theme` and updating version XST version

**Benefits:**
- Allows users to search all PennyLane content via command palette interface.

**Possible Drawbacks:**
- None

**Related GitHub Issues:**
- None
