### PR TITLE
sc-81896-disable-search-page-redirect-on-all-docs-projects-except-pennylane-oss

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,8 +1,12 @@
-## Release 0.9.0 (development release)
+## Release 0.9.0
 
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
+
+### Bug Fixes
+* Disabled the `search_on_pennylane_ai` configuration by default so that it can be enabled selectively in docs projects.
+  [#85](https://github.com/PennyLaneAI/pennylane-sphinx-theme/pull/85)
 
 ## Release 0.8.0
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 This release contains contributions from (in alphabetical order):
 
+[Ashish Kanwar Singh](https://github.com/ashishks0522).
+
 ### Bug Fixes
 * Disabled the `search_on_pennylane_ai` configuration by default so that it can be enabled selectively in docs projects.
   [#85](https://github.com/PennyLaneAI/pennylane-sphinx-theme/pull/85)

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -101,6 +101,7 @@ html_theme_options = {
     "toc_global": True,
     "relations": True,
     "command_palette_enabled": False,
+    "search_on_pennylane_ai": False
 }
 
 

--- a/pennylane_sphinx_theme/theme.conf
+++ b/pennylane_sphinx_theme/theme.conf
@@ -59,7 +59,7 @@ google_analytics_tracking_id =
 extra_copyrights =
 
 # Whether to redirect searches to https://pennylane.ai/search.
-search_on_pennylane_ai = True
+search_on_pennylane_ai = False
 
 # Whether to enable the pennylane command palette. 
 command_palette_enabled = False


### PR DESCRIPTION
## Changes
- Make search on PennyLane.ai feature disabled by default and to be only enabled explicitly in docs projects

## Related PR
- https://github.com/PennyLaneAI/pennylane/pull/6816