### PR TITLE
SC80682 | fix deprecation issues

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -10,6 +10,7 @@ This release contains contributions from (in alphabetical order):
 
 - Update `name` in `setup.py` so the build does not use `-` in the name. This is to comply with [PEP 625](https://peps.python.org/pep-0625/), which is causing deprication warnings from PyPI
 - Update year in footer to 2025
+- Disable hotkeys in theme
 
 ## Release 0.9.0
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -9,7 +9,7 @@ This release contains contributions from (in alphabetical order):
 ### Features
 
 - Update `name` in `setup.py` so the build does not use `-` in the name. This is to comply with [PEP 625](https://peps.python.org/pep-0625/), which is causing deprication warnings from PyPI
-- Update year in footer to 2025
+- Update year in footer
 - Disable hotkeys in theme
 
 ## Release 0.9.0

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,3 +1,16 @@
+## Release 0.9.1
+
+### Contributors
+
+This release contains contributions from (in alphabetical order):
+
+- [Andrew Gardhouse](https://github.com/AndrewGardhouse)
+
+### Features
+
+- Update `name` in `setup.py` so the build does not use `-` in the name. This is to comply with [PEP 625](https://peps.python.org/pep-0625/), which is causing deprication warnings from PyPI
+- Update year in footer to 2025
+
 ## Release 0.9.0
 
 ### Contributors

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -19,6 +19,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
+          pip install --upgrade pip setuptools
           pip install -r requirements-dev.txt
 
       - name: Install the Xanadu Sphinx Theme

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -15,11 +15,12 @@
 # sys.path.insert(0, os.path.abspath('.'))
 
 import re
+from datetime import datetime
 
 # -- Project information -----------------------------------------------------
 
 project = 'PennyLane Sphinx Theme'
-copyright = '2025 | Xanadu | All rights reserved'
+copyright = f"{datetime.now().year} | Xanadu | All rights reserved"
 author = 'Xanadu Inc.'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -101,7 +101,8 @@ html_theme_options = {
     "toc_global": True,
     "relations": True,
     "command_palette_enabled": False,
-    "search_on_pennylane_ai": False
+    "search_on_pennylane_ai": False,
+    "hotkeys": False
 }
 
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -19,7 +19,7 @@ import re
 # -- Project information -----------------------------------------------------
 
 project = 'PennyLane Sphinx Theme'
-copyright = '2023 | Xanadu | All rights reserved'
+copyright = '2025 | Xanadu | All rights reserved'
 author = 'Xanadu Inc.'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -11,4 +11,4 @@ sphinxcontrib-htmlhelp==2.0.1
 sphinxcontrib-serializinghtml==1.1.5
 sphinx-copybutton
 sphinx-gallery==0.10.1
-xanadu-sphinx-theme==0.7.0
+xanadu-sphinx-theme==0.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 sphinx==4.5.0
 pillow==10.3.0
 sphinx-gallery==0.10.1
-xanadu-sphinx-theme==0.7.0
+xanadu-sphinx-theme==0.8.0

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ info = {
     "long_description": open("README.rst").read(),
     "long_description_content_type": "text/x-rst",
     "include_package_data": True,
-    "name": "pennylane_sphinx_theme",
+    "name": "pennylane-sphinx-theme",
     "packages": find_packages(where="."),
     "package_data": {"pennylane_sphinx_theme": ["static/*", "*.html", "theme.conf"]},
     "provides": ["pennylane_sphinx_theme"],

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("pennylane_sphinx_theme/_version.py") as f:
 
 requirements = [
     "sphinx",
-    "xanadu-sphinx-theme~=0.7.0",
+    "xanadu-sphinx-theme~=0.8.0",
     # The packages below are used to generate thumbnail images.
     "pillow",
     "sphinx-gallery",

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ info = {
     "long_description": open("README.rst").read(),
     "long_description_content_type": "text/x-rst",
     "include_package_data": True,
-    "name": "pennylane-sphinx-theme",
+    "name": "pennylane_sphinx_theme",
     "packages": find_packages(where="."),
     "package_data": {"pennylane_sphinx_theme": ["static/*", "*.html", "theme.conf"]},
     "provides": ["pennylane_sphinx_theme"],


### PR DESCRIPTION
**Context:**
https://app.shortcut.com/xanaduai/story/80682/fix-deprecation-issues-with-pennylane-sphinx-theme

**Description of the Change:**
- Update `name` to comply with [PEP 625](https://peps.python.org/pep-0625/) 
- Update year in footer

**Benefits:**
- Resolves deprecation warnings from Pypi
- The correct year is shown in the footer

**Possible Drawbacks:**
NA

**Related GitHub Issues:**
NA