### PR TITLE
sc-77880-automate-release-and-version-bump-in-pennylane

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,10 +1,17 @@
-## Release 0.14.0 (development release)
+## Release 0.14.0 (current release)
 
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
 
-## Release 0.13.0 (current release)
+[Ashish Kanwar Singh](https://github.com/ashishks0522).
+
+### Features
+
+- Streamlining release process for pennylane-sphinx-theme to automatically trigger pre-release workflow and package release.
+- Added Andrew & Jon as codeowners for releases.
+
+## Release 0.13.0
 
 ### Contributors
 

--- a/.github/workflows/create-release-tag-and-notes.yml
+++ b/.github/workflows/create-release-tag-and-notes.yml
@@ -39,5 +39,3 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release create ${{ steps.taggerDryRun.outputs.new_tag }} --generate-notes --notes-start-tag ${{ steps.taggerDryRun.outputs.tag }}
-  
-  

--- a/.github/workflows/create-release-tag-and-notes.yml
+++ b/.github/workflows/create-release-tag-and-notes.yml
@@ -1,3 +1,5 @@
+# This action creates automatic release for pennylane-sphinx-theme
+# when pre-release-version-bump branch is merged into master
 on:
   pull_request:
     types:

--- a/.github/workflows/create-release-tag-and-notes.yml
+++ b/.github/workflows/create-release-tag-and-notes.yml
@@ -1,0 +1,43 @@
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - master
+  
+jobs:
+    Minor:
+      # Only trigger automatic release when pre-release branch in merged into main
+      if: github.event.pull_request.merged == true && github.head_ref == 'pre-release-version-bump'
+      runs-on: ubuntu-latest
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: '0'
+      - name: Minor version for each merge
+        id: taggerDryRun
+        uses: anothrNick/github-tag-action@1.36.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WITH_V: true
+          DRY_RUN: true
+          DEFAULT_BUMP: minor
+  
+      - name: echo new tag
+        run: |
+          echo "The next tag version will be: ${{ steps.taggerDryRun.outputs.new_tag }}"
+      - name: echo tag
+        run: |
+          echo "The current tag is: ${{ steps.taggerDryRun.outputs.tag }}"
+      - name: echo part
+        run: |
+          echo "The version increment was: ${{ steps.taggerDryRun.outputs.part }}"
+      - name: Publish release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create ${{ steps.taggerDryRun.outputs.new_tag }} --generate-notes --notes-start-tag ${{ steps.taggerDryRun.outputs.tag }}
+  
+  

--- a/.github/workflows/post_release_version_bump.yml
+++ b/.github/workflows/post_release_version_bump.yml
@@ -1,3 +1,4 @@
+# Create an automatic post-release version bump after a release.
 name: Post-Release Version Bump
 
 on:

--- a/.github/workflows/post_release_version_bump.yml
+++ b/.github/workflows/post_release_version_bump.yml
@@ -49,4 +49,4 @@ jobs:
             to `${{ steps.versions.outputs.new_version }}`.
           commit-message: Bump version to `${{ steps.versions.outputs.new_version }}`
           branch: post-release-version-bump
-          reviewers: ashishks0522, Alan-eMartin, doctorperceptron, josh146
+          reviewers: ashishks0522, Alan-eMartin, jontoye, AndrewGardhouse, doctorperceptron, josh146

--- a/.github/workflows/post_release_version_bump.yml
+++ b/.github/workflows/post_release_version_bump.yml
@@ -1,4 +1,4 @@
-# Create an automatic post-release version bump after a release.
+# Create an automatic post-release version bump PR after a release.
 name: Post-Release Version Bump
 
 on:

--- a/.github/workflows/pre_release_version_bump.yml
+++ b/.github/workflows/pre_release_version_bump.yml
@@ -1,7 +1,9 @@
 name: Pre-Release Version Bump
 
 on:
-  workflow_dispatch:
+  push:
+    branches:
+      - master
 
 jobs:
   pre_release_version_bump:
@@ -38,4 +40,4 @@ jobs:
             to `${{ steps.versions.outputs.new_version }}`.
           commit-message: Bump version to `${{ steps.versions.outputs.new_version }}`
           branch: pre-release-version-bump
-          reviewers: ashishks0522, Alan-eMartin, doctorperceptron, josh146
+          reviewers: ashishks0522, Alan-eMartin, jontoye, AndrewGardhouse, doctorperceptron, josh146

--- a/.github/workflows/pre_release_version_bump.yml
+++ b/.github/workflows/pre_release_version_bump.yml
@@ -1,3 +1,4 @@
+# Create an automatic pre-release version bump PR on merge to master
 name: Pre-Release Version Bump
 
 on:

--- a/README.rst
+++ b/README.rst
@@ -82,9 +82,16 @@ Release
 
 .. release-start-inclusion-marker-do-not-remove
 
-- When a pull request (PR) is merged into the ``master`` branch, a new PR is opened from the ``pre-release-version-bump`` branch into ``master`` which aims to update the development version in the ``_version.py`` file. 
-- Once the pre-release PR is merged into ``master``, it triggers an automatic release that bumps up the minor version of the project. 
-- Additionally, it opens a PR from ``post-release-version-bump`` branch, which manages the version increment after the current version has been released.
+1. Make a PR with the desired changes to the PST (pennylane-sphinx-theme).
+    - Don’t forget to update the ``CHANGELOG``!
+2. Merge in your PR once it is approved.
+3. Prepare the PST for release.
+    - Once PR is merged it will trigger the [Pre-Release Version Bump](https://github.com/PennyLaneAI/pennylane-sphinx-theme/actions/workflows/pre_release_version_bump.yml) workflow.
+    - Adjust the release version number as necessary.
+    - Merge in the ``Pre-release version bump to X.Y.Z`` PR.
+4. Release a new version of the PST.
+    - Once ``Pre-release version bump to X.Y.Z`` PR is merged in it will automatically create new release of PST
+    - And open a ``Post-release version bump to X.Y.Z`` PR that can be merged in to increment the version for next release.
 
 .. release-end-inclusion-marker-do-not-remove
 

--- a/README.rst
+++ b/README.rst
@@ -84,12 +84,12 @@ Release
 
 1. Make a PR with the desired changes to the PST (pennylane-sphinx-theme).
     - Don’t forget to update the ``CHANGELOG``!
-2. Merge in your PR once it is approved.
-3. Prepare the PST for release.
+    - Merge in your PR once it is approved.
+2. Prepare the PST for release.
     - Once PR is merged it will trigger the [Pre-Release Version Bump](https://github.com/PennyLaneAI/pennylane-sphinx-theme/actions/workflows/pre_release_version_bump.yml) workflow.
     - Adjust the release version number as necessary.
     - Merge in the ``Pre-release version bump to X.Y.Z`` PR.
-4. Release a new version of the PST.
+3. Release a new version of the PST.
     - Once ``Pre-release version bump to X.Y.Z`` PR is merged in it will automatically create new release of PST
     - And open a ``Post-release version bump to X.Y.Z`` PR that can be merged in to increment the version for next release.
 

--- a/README.rst
+++ b/README.rst
@@ -77,6 +77,17 @@ For more details, please see the
 
 .. directives-end-inclusion-marker-do-not-remove
 
+Release
+============
+
+.. release-start-inclusion-marker-do-not-remove
+
+- When a pull request (PR) is merged into the `master` branch, a new PR is opened from the `pre-release-version-bump` branch into `master` which aims to update the development version in the `_version.py` file. 
+- Once the pre-release PR is merged into `master`, it triggers an automatic release that bumps up the minor version of the project. 
+- Additionally, it opens a PR from `post-release-version-bump` branch, which manages the version increment after the current version has been released.
+
+.. release-end-inclusion-marker-do-not-remove
+
 Support
 =======
 

--- a/README.rst
+++ b/README.rst
@@ -87,7 +87,7 @@ Release
     - Merge in your PR once it is approved.
 2. Prepare the PST for release.
     - Once PR is merged it will trigger the `Pre-Release Version Bump <https://github.com/PennyLaneAI/pennylane-sphinx-theme/actions/workflows/pre_release_version_bump.yml>`__ workflow.
-    - Adjust the release version number as necessary.
+    - The workflow will open a PR ``Pre-release version bump to X.Y.Z``. Adjust the release version number as necessary.
     - Merge in the ``Pre-release version bump to X.Y.Z`` PR.
 3. Release a new version of the PST.
     - Once ``Pre-release version bump to X.Y.Z`` PR is merged in it will automatically create new release of PST.

--- a/README.rst
+++ b/README.rst
@@ -86,12 +86,13 @@ Release
     - Don’t forget to update the ``CHANGELOG``!
     - Merge in your PR once it is approved.
 2. Prepare the PST for release.
-    - Once PR is merged it will trigger the [Pre-Release Version Bump](https://github.com/PennyLaneAI/pennylane-sphinx-theme/actions/workflows/pre_release_version_bump.yml) workflow.
+    - Once PR is merged it will trigger the `Pre-Release Version Bump <https://github.com/PennyLaneAI/pennylane-sphinx-theme/actions/workflows/pre_release_version_bump.yml>`__ workflow.
     - Adjust the release version number as necessary.
     - Merge in the ``Pre-release version bump to X.Y.Z`` PR.
 3. Release a new version of the PST.
-    - Once ``Pre-release version bump to X.Y.Z`` PR is merged in it will automatically create new release of PST
-    - And open a ``Post-release version bump to X.Y.Z`` PR that can be merged in to increment the version for next release.
+    - Once ``Pre-release version bump to X.Y.Z`` PR is merged in it will automatically create new release of PST.
+    - It will also run the `Post-Release Version Bump <https://github.com/PennyLaneAI/pennylane-sphinx-theme/actions/workflows/post_release_version_bump.yml>`__ workflow. 
+    - The workflow will open a ``Post-release version bump to X.Y.Z`` PR that can be merged in ``master`` to increment the version for next release.
 
 .. release-end-inclusion-marker-do-not-remove
 

--- a/README.rst
+++ b/README.rst
@@ -82,9 +82,9 @@ Release
 
 .. release-start-inclusion-marker-do-not-remove
 
-- When a pull request (PR) is merged into the `master` branch, a new PR is opened from the `pre-release-version-bump` branch into `master` which aims to update the development version in the `_version.py` file. 
-- Once the pre-release PR is merged into `master`, it triggers an automatic release that bumps up the minor version of the project. 
-- Additionally, it opens a PR from `post-release-version-bump` branch, which manages the version increment after the current version has been released.
+- When a pull request (PR) is merged into the ``master`` branch, a new PR is opened from the ``pre-release-version-bump`` branch into ``master`` which aims to update the development version in the ``_version.py`` file. 
+- Once the pre-release PR is merged into ``master``, it triggers an automatic release that bumps up the minor version of the project. 
+- Additionally, it opens a PR from ``post-release-version-bump`` branch, which manages the version increment after the current version has been released.
 
 .. release-end-inclusion-marker-do-not-remove
 


### PR DESCRIPTION
## Changes
- Streamlining release process for `pennylane-sphinx-theme` to automatically trigger pre-release workflow and package release.

      
![Screenshot 2025-04-07 at 2 37 28 PM](https://github.com/user-attachments/assets/1fb45aa4-e998-4b95-afcd-c72a29736421)

      
- Added Andrew & Jon as codeowners for releases. 
- Updated `README` & [notion doc](https://www.notion.so/xanaduai/Making-Sense-of-Sphinx-12dbc6bd176480bea291cc1fd4dd0de8?pvs=4#12ebc6bd1764807da55ce068aae0322c) for sphinx releases

## Ticket
- [sc-77880-automate-release-and-version-bump-in-pennylane](https://app.shortcut.com/xanaduai/story/77880/automate-release-and-version-bump-in-pennylane-sphinx-theme)

## Workflow Test Runs
- Tested the workflow in another repo: [Action Run](https://github.com/XanaduAI/web-easter-eggs/actions/runs/14315710326)
- Once merged I will verify that actions works in `pennylane-sphinx-theme` as expected and follow up with any fixes needed.