### PR TITLE
add manual trigger and workflow link for post release

### DIFF
--- a/.github/workflows/create-release-tag-and-notes.yml
+++ b/.github/workflows/create-release-tag-and-notes.yml
@@ -1,5 +1,7 @@
 # This action creates automatic release for pennylane-sphinx-theme
 # when pre-release-version-bump branch is merged into master
+name: Release
+
 on:
   pull_request:
     types:

--- a/.github/workflows/post_release_version_bump.yml
+++ b/.github/workflows/post_release_version_bump.yml
@@ -2,9 +2,11 @@
 name: Post-Release Version Bump
 
 on:
-  release:
+  workflow_run:
+    workflows: [Release]
     types:
-      - published
+      - completed
+  workflow_dispatch:
 
 jobs:
   post_release_version_bump:

--- a/.github/workflows/pre_release_version_bump.yml
+++ b/.github/workflows/pre_release_version_bump.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - master
+  workflow_dispatch:
 
 jobs:
   pre_release_version_bump:


### PR DESCRIPTION
## Changes
- Follow-up to https://github.com/PennyLaneAI/pennylane-sphinx-theme/pull/102
- Adds support to trigger pre/post release bump actions manually (In case needed)
- Automatic release don't trigger post release action as GitHub prevents that in case of automatic release. Hence linking it with `workflow_run` to trigger after a release is made.