### PR TITLE
fix-action-running-in-recursion

### DIFF
--- a/.github/workflows/create-release-tag-and-notes.yml
+++ b/.github/workflows/create-release-tag-and-notes.yml
@@ -1,5 +1,7 @@
 # This action creates automatic release for pennylane-sphinx-theme
 # when pre-release-version-bump branch is merged into master
+name: Release
+
 on:
   pull_request:
     types:

--- a/.github/workflows/create-release-tag-and-notes.yml
+++ b/.github/workflows/create-release-tag-and-notes.yml
@@ -43,3 +43,9 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release create ${{ steps.taggerDryRun.outputs.new_tag }} --generate-notes --notes-start-tag ${{ steps.taggerDryRun.outputs.tag }}
+
+      - name: Trigger Post Release Workflow
+        uses: peter-evans/repository-dispatch@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          event-type: run-post-release-bump

--- a/.github/workflows/post_release_version_bump.yml
+++ b/.github/workflows/post_release_version_bump.yml
@@ -2,9 +2,11 @@
 name: Post-Release Version Bump
 
 on:
-  release:
+  workflow_run:
+    workflows: [Release]
     types:
-      - published
+      - completed
+  workflow_dispatch:
 
 jobs:
   post_release_version_bump:

--- a/.github/workflows/post_release_version_bump.yml
+++ b/.github/workflows/post_release_version_bump.yml
@@ -2,10 +2,8 @@
 name: Post-Release Version Bump
 
 on:
-  workflow_run:
-    workflows: [Release]
-    types:
-      - completed
+  repository_dispatch:
+    types: [run-post-release-bump]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/pre_release_version_bump.yml
+++ b/.github/workflows/pre_release_version_bump.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - master
+  workflow_dispatch:
 
 jobs:
   pre_release_version_bump:


### PR DESCRIPTION
## Changes
- Issue caused by https://github.com/PennyLaneAI/pennylane-sphinx-theme/pull/104 where on workflow complete runs everytime even when the release workflow is skipped
- Updated post release to be a step in `create-release-tag-and-notes.yml` so that its only executed when a release happens.

## Testing
- Will verify after merging in and follow up with any fixes needed.