### PR TITLE
update-upload-action-to-work-with-automatic-release

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -10,7 +10,7 @@ This release contains contributions from (in alphabetical order):
 
 [Ashish Kanwar Singh](https://github.com/ashishks0522).
 
-## Release 0.15.0
+ ## Release 0.15.0 (current release)
 
 ### Features
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,8 +1,14 @@
 ## Release 0.15.0 (current release)
 
+### Features
+
+- Fix upload action not triggering
+
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
+
+[Ashish Kanwar Singh](https://github.com/ashishks0522).
 
 ## Release 0.14.0
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,11 +1,5 @@
 ## Release 0.16.0 (development release)
 
-### Contributors
-
-This release contains contributions from (in alphabetical order):
-
-## Release 0.15.0 (current release)
-
 ### Features
 
 - Fix upload action not triggering
@@ -15,6 +9,14 @@ This release contains contributions from (in alphabetical order):
 This release contains contributions from (in alphabetical order):
 
 [Ashish Kanwar Singh](https://github.com/ashishks0522).
+
+## Release 0.15.0
+
+### Features
+
+### Contributors
+
+This release contains contributions from (in alphabetical order):
 
 ## Release 0.14.0
 

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -1,8 +1,7 @@
 name: Upload
 on:
-  release:
-    types:
-      - published
+  repository_dispatch:
+    types: [run-post-release-bump]
 
 jobs:
   upload:


### PR DESCRIPTION
## Changes
- Automation of release causes actions to not trigger by default if they rely on a release published trigger.
- Updating it to use `repository_dispatch`