### PR TITLE
update-xst-to-16

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,10 +1,16 @@
-## Release 0.24.0 (development release)
+## Release 0.24.0  (current release)
+
+### Features
+
+- Update xanadu-sphinx-theme to version 0.16.0
 
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
 
-## Release 0.23.0 (current release)
+[Ashish Kanwar Singh](https://github.com/ashishks0522)
+
+## Release 0.23.0
 
 ### Contributors
 

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -11,4 +11,4 @@ sphinxcontrib-htmlhelp==2.0.1
 sphinxcontrib-serializinghtml==1.1.5
 sphinx-copybutton
 sphinx-gallery==0.10.1
-xanadu-sphinx-theme==0.15.0
+xanadu-sphinx-theme==0.16.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 sphinx==4.5.0
 pillow==10.3.0
 sphinx-gallery==0.10.1
-xanadu-sphinx-theme==0.15.0
+xanadu-sphinx-theme==0.16.0

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("pennylane_sphinx_theme/_version.py") as f:
 
 requirements = [
     "sphinx",
-    "xanadu-sphinx-theme~=0.15.0",
+    "xanadu-sphinx-theme~=0.16.0",
     # The packages below are used to generate thumbnail images.
     "pillow",
     "sphinx-gallery",


### PR DESCRIPTION
## Changes
- Update xanadu-sphinx-theme to version 0.16.0 includes https://github.com/XanaduAI/xanadu-sphinx-theme/pull/96