### PR TITLE
Bump xanadu-sphinx-theme-version to 0.19.0

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Release 0.29.0 (development release)
 
+### Features
+
+- Update xanadu-sphinx-theme to version 0.19.0
+
 ### Contributors
 
 This release contains contributions from (in alphabetical order):

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -13,4 +13,4 @@ sphinxcontrib-htmlhelp==2.0.1
 sphinxcontrib-serializinghtml==1.1.5
 sphinx-copybutton
 sphinx-gallery==0.10.1
-xanadu-sphinx-theme==0.18.0
+xanadu-sphinx-theme==0.19.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 sphinx==4.5.0
 pillow==10.3.0
 sphinx-gallery==0.10.1
-xanadu-sphinx-theme==0.18.0
+xanadu-sphinx-theme==0.19.0

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("pennylane_sphinx_theme/_version.py") as f:
 
 requirements = [
     "sphinx",
-    "xanadu-sphinx-theme==0.18.0",
+    "xanadu-sphinx-theme==0.19.0",
     # The packages below are used to generate thumbnail images.
     "pillow",
     "sphinx-gallery",


### PR DESCRIPTION
## Changes
- Bump xanadu-sphinx-theme-version to 0.19.0
- To include https://github.com/XanaduAI/xanadu-sphinx-theme/pull/108