### PR TITLE
[SC-121581] Port global `navbar` to sphinx documentation

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 This release contains contributions from (in alphabetical order):
 
+[Koeun Lee](https://github.com/koeun-lee)
+
+### Features
+
+- Defined the navbar content for PennyLane's new global navbar, replacing the old dropdown structure with multi-column link sections (with icons) and featured/content/latest-release cards. The rendering templates live in `xanadu-sphinx-theme`.
+
 ## Release 0.29.0 (current release)
 
 ### Features

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -13,4 +13,4 @@ sphinxcontrib-htmlhelp==2.0.1
 sphinxcontrib-serializinghtml==1.1.5
 sphinx-copybutton
 sphinx-gallery==0.10.1
-xanadu-sphinx-theme @ git+https://github.com/XanaduAI/xanadu-sphinx-theme.git@feature/navbar-footer-redesign
+xanadu-sphinx-theme @ git+https://github.com/XanaduAI/xanadu-sphinx-theme.git@sc-121581-port-global-navbar-to-sphinx-documentation

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -13,4 +13,4 @@ sphinxcontrib-htmlhelp==2.0.1
 sphinxcontrib-serializinghtml==1.1.5
 sphinx-copybutton
 sphinx-gallery==0.10.1
-xanadu-sphinx-theme @ git+https://github.com/XanaduAI/xanadu-sphinx-theme.git@sc-121581-port-global-navbar-to-sphinx-documentation
+xanadu-sphinx-theme==0.20.0

--- a/doc/sg_execution_times.rst
+++ b/doc/sg_execution_times.rst
@@ -1,0 +1,37 @@
+
+:orphan:
+
+.. _sphx_glr_sg_execution_times:
+
+
+Computation times
+=================
+**00:00.000** total execution time for 1 file **from all galleries**:
+
+.. container::
+
+  .. raw:: html
+
+    <style scoped>
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/5.3.0/css/bootstrap.min.css" rel="stylesheet" />
+    <link href="https://cdn.datatables.net/1.13.6/css/dataTables.bootstrap5.min.css" rel="stylesheet" />
+    </style>
+    <script src="https://code.jquery.com/jquery-3.7.0.js"></script>
+    <script src="https://cdn.datatables.net/1.13.6/js/jquery.dataTables.min.js"></script>
+    <script src="https://cdn.datatables.net/1.13.6/js/dataTables.bootstrap5.min.js"></script>
+    <script type="text/javascript" class="init">
+    $(document).ready( function () {
+        $('table.sg-datatable').DataTable({order: [[1, 'desc']]});
+    } );
+    </script>
+
+  .. list-table::
+   :header-rows: 1
+   :class: table table-striped sg-datatable
+
+   * - Example
+     - Time
+     - Mem (MB)
+   * - :ref:`sphx_glr_gallery_tutorial_demo.py` (``tutorials/tutorial_demo.py``)
+     - 00:00.000
+     - 0.0

--- a/pennylane_sphinx_theme/footer.py
+++ b/pennylane_sphinx_theme/footer.py
@@ -4,7 +4,7 @@ This module contains the common PennyLane footer data.
 
 import textwrap
 
-from .urls import PENNYLANE_WEBSITE, pl
+from .urls import PENNYLANE_WEBSITE, pl_url
 
 PENNYLANE_LOGO = "https://assets.cloud.pennylane.ai/pennylane_website/generic/pennylane-logo.png"
 XANADU_LOGO = "https://assets.cloud.pennylane.ai/pennylane_website/generic/xanadu-logo.png"
@@ -43,19 +43,19 @@ FOOTER = {
     "footer_policies": [
         {
             "text": "Privacy policy",
-            "href": pl("/privacy"),
+            "href": pl_url("/privacy"),
         },
         {
             "text": "Terms of service",
-            "href": pl("/terms"),
+            "href": pl_url("/terms"),
         },
         {
             "text": "Cookies policy",
-            "href": pl("/cookies"),
+            "href": pl_url("/cookies"),
         },
         {
             "text": "Code of conduct",
-            "href": pl("/conduct"),
+            "href": pl_url("/conduct"),
         },
     ],
     "footer_links": [
@@ -64,27 +64,27 @@ FOOTER = {
             "links": [
                 {
                     "name": "Research",
-                    "href": pl("/research"),
+                    "href": pl_url("/research"),
                 },
                 {
                     "name": "Performance",
-                    "href": pl("/performance"),
+                    "href": pl_url("/performance"),
                 },
                 {
                     "name": "Hardware and simulators",
-                    "href": pl("/devices"),
+                    "href": pl_url("/devices"),
                 },
                 {
                     "name": "Demos library",
-                    "href": pl("/demonstrations"),
+                    "href": pl_url("/demonstrations"),
                 },
                 {
                     "name": "Compilation hub",
-                    "href": pl("/compilation"),
+                    "href": pl_url("/compilation"),
                 },
                 {
                     "name": "Quantum datasets",
-                    "href": pl("/datasets"),
+                    "href": pl_url("/datasets"),
                 },
             ],
         },
@@ -93,27 +93,27 @@ FOOTER = {
             "links": [
                 {
                     "name": "Teach",
-                    "href": pl("/education"),
+                    "href": pl_url("/education"),
                 },
                 {
                     "name": "Learn",
-                    "href": pl("/learn"),
+                    "href": pl_url("/learn"),
                 },
                 {
                     "name": "Codebook",
-                    "href": pl("/codebook"),
+                    "href": pl_url("/codebook"),
                 },
                 {
                     "name": "Coding challenges",
-                    "href": pl("/challenges"),
+                    "href": pl_url("/challenges"),
                 },
                 {
                     "name": "Videos",
-                    "href": pl("/videos"),
+                    "href": pl_url("/videos"),
                 },
                 {
                     "name": "Glossary",
-                    "href": pl("/glossary"),
+                    "href": pl_url("/glossary"),
                 },
             ],
         },
@@ -122,11 +122,11 @@ FOOTER = {
             "links": [
                 {
                     "name": "Install",
-                    "href": pl("/install"),
+                    "href": pl_url("/install"),
                 },
                 {
                     "name": "Features",
-                    "href": pl("/features"),
+                    "href": pl_url("/features"),
                 },
                 {
                     "name": "PennyLane documentation",
@@ -142,7 +142,7 @@ FOOTER = {
                 },
                 {
                     "name": "How-to guides",
-                    "href": pl("/search/?contentType=DEMO&categories=how-to&sort=publication_date"),
+                    "href": pl_url("/search/?contentType=DEMO&categories=how-to&sort=publication_date"),
                 },
                 {
                     "name": "API",

--- a/pennylane_sphinx_theme/footer.py
+++ b/pennylane_sphinx_theme/footer.py
@@ -142,9 +142,7 @@ FOOTER = {
                 },
                 {
                     "name": "How-to guides",
-                    "href": pl(
-                        "/search/?contentType=DEMO&categories=how-to&sort=publication_date"
-                    ),
+                    "href": pl("/search/?contentType=DEMO&categories=how-to&sort=publication_date"),
                 },
                 {
                     "name": "API",

--- a/pennylane_sphinx_theme/footer.py
+++ b/pennylane_sphinx_theme/footer.py
@@ -4,17 +4,10 @@ This module contains the common PennyLane footer data.
 
 import textwrap
 
-PENNYLANE_WEBSITE = "https://pennylane.ai"
+from .urls import PENNYLANE_WEBSITE, pl
 
 PENNYLANE_LOGO = "https://assets.cloud.pennylane.ai/pennylane_website/generic/pennylane-logo.png"
 XANADU_LOGO = "https://assets.cloud.pennylane.ai/pennylane_website/generic/xanadu-logo.png"
-
-
-def _pl(path):
-    """Return an absolute pennylane.ai URL for website paths."""
-    if path.startswith("http"):
-        return path
-    return f"{PENNYLANE_WEBSITE}{path}"
 
 
 FOOTER = {
@@ -50,19 +43,19 @@ FOOTER = {
     "footer_policies": [
         {
             "text": "Privacy policy",
-            "href": _pl("/privacy"),
+            "href": pl("/privacy"),
         },
         {
             "text": "Terms of service",
-            "href": _pl("/terms"),
+            "href": pl("/terms"),
         },
         {
-            "text": "Cookie policy",
-            "href": _pl("/cookies"),
+            "text": "Cookies policy",
+            "href": pl("/cookies"),
         },
         {
             "text": "Code of conduct",
-            "href": _pl("/conduct"),
+            "href": pl("/conduct"),
         },
     ],
     "footer_links": [
@@ -71,27 +64,27 @@ FOOTER = {
             "links": [
                 {
                     "name": "Research",
-                    "href": _pl("/research"),
+                    "href": pl("/research"),
                 },
                 {
                     "name": "Performance",
-                    "href": _pl("/performance"),
+                    "href": pl("/performance"),
                 },
                 {
                     "name": "Hardware and simulators",
-                    "href": _pl("/devices"),
+                    "href": pl("/devices"),
                 },
                 {
                     "name": "Demos library",
-                    "href": _pl("/demonstrations"),
+                    "href": pl("/demonstrations"),
                 },
                 {
                     "name": "Compilation hub",
-                    "href": _pl("/compilation"),
+                    "href": pl("/compilation"),
                 },
                 {
                     "name": "Quantum datasets",
-                    "href": _pl("/datasets"),
+                    "href": pl("/datasets"),
                 },
             ],
         },
@@ -100,27 +93,27 @@ FOOTER = {
             "links": [
                 {
                     "name": "Teach",
-                    "href": _pl("/education"),
+                    "href": pl("/education"),
                 },
                 {
                     "name": "Learn",
-                    "href": _pl("/learn"),
+                    "href": pl("/learn"),
                 },
                 {
                     "name": "Codebook",
-                    "href": _pl("/codebook"),
+                    "href": pl("/codebook"),
                 },
                 {
                     "name": "Coding challenges",
-                    "href": _pl("/challenges"),
+                    "href": pl("/challenges"),
                 },
                 {
                     "name": "Videos",
-                    "href": _pl("/videos"),
+                    "href": pl("/videos"),
                 },
                 {
                     "name": "Glossary",
-                    "href": _pl("/glossary"),
+                    "href": pl("/glossary"),
                 },
             ],
         },
@@ -129,11 +122,11 @@ FOOTER = {
             "links": [
                 {
                     "name": "Install",
-                    "href": _pl("/install"),
+                    "href": pl("/install"),
                 },
                 {
                     "name": "Features",
-                    "href": _pl("/features"),
+                    "href": pl("/features"),
                 },
                 {
                     "name": "PennyLane documentation",
@@ -149,7 +142,7 @@ FOOTER = {
                 },
                 {
                     "name": "How-to guides",
-                    "href": _pl(
+                    "href": pl(
                         "/search/?contentType=DEMO&categories=how-to&sort=publication_date"
                     ),
                 },

--- a/pennylane_sphinx_theme/footer.py
+++ b/pennylane_sphinx_theme/footer.py
@@ -142,7 +142,9 @@ FOOTER = {
                 },
                 {
                     "name": "How-to guides",
-                    "href": pl_url("/search/?contentType=DEMO&categories=how-to&sort=publication_date"),
+                    "href": pl_url(
+                        "/search?contentType=DEMO&categories=how-to&sort=publication_date"
+                    ),
                 },
                 {
                     "name": "API",

--- a/pennylane_sphinx_theme/navbar.py
+++ b/pennylane_sphinx_theme/navbar.py
@@ -284,8 +284,8 @@ TOPIC_GUIDES = {
                             "pill": {
                                 "text": "New",
                                 "variant": "in-progress",
-                                "startDate": "2026-05-01",
-                                "expiryDate": "2026-07-01",
+                                "startDate": "2026-06-19",
+                                "expiryDate": "2026-07-22",
                             },
                             "description": "Explore the definitive PennyLane Guide to quantum compilation techniques.",
                         },
@@ -340,6 +340,8 @@ TOPIC_GUIDES = {
                     "pill": {
                         "text": "New",
                         "variant": "in-progress",
+                        "startDate": "2026-06-19",
+                        "expiryDate": "2026-07-22",
                     },
                 },
             ],
@@ -352,6 +354,8 @@ COMMUNITY_SUPPORT = {
     "pill": {
         "text": "New",
         "variant": "info",
+        "startDate": "2026-06-19",
+        "expiryDate": "2026-08-01",
     },
     "linkSections": [
         {
@@ -450,6 +454,8 @@ COMMUNITY_SUPPORT = {
                     "pill": {
                         "text": "New",
                         "variant": "info",
+                        "startDate": "2026-06-19",
+                        "expiryDate": "2026-08-01",
                     },
                 },
             ],

--- a/pennylane_sphinx_theme/navbar.py
+++ b/pennylane_sphinx_theme/navbar.py
@@ -2,154 +2,464 @@
 This module contains the common PennyLane navigation bar data.
 """
 
+WHY_PENNYLANE = {
+    "name": "Why PennyLane",
+    "linkSections": [
+        {
+            "columns": 1,
+            "sections": [
+                {
+                    "header": "About PennyLane",
+                    "items": [
+                        {
+                            "name": "Features",
+                            "href": "https://pennylane.ai/features",
+                            "description": "Discover easy-to-use PennyLane features to empower your work.",
+                        },
+                        {
+                            "name": "Performance",
+                            "href": "https://pennylane.ai/performance",
+                            "description": "Scale up your workflows on GPUs and supercomputers to accelerate simulations.",
+                        },
+                        {
+                            "name": "Hardware and simulators",
+                            "href": "https://pennylane.ai/devices",
+                            "description": "Explore PennyLane's quantum device ecosystem with 40+ integrated options.",
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            "columns": 1,
+            "sections": [
+                {
+                    "header": "Use Cases & Applications",
+                    "items": [
+                        {
+                            "name": "Research",
+                            "href": "https://pennylane.ai/research",
+                            "description": "Accelerate your quantum computing research breakthroughs with PennyLane.",
+                        },
+                        {
+                            "name": "Teach",
+                            "href": "https://pennylane.ai/education",
+                            "description": "Join quantum educators in over 130 universities using PennyLane in the classroom.",
+                        },
+                        {
+                            "name": "Learn",
+                            "href": "https://pennylane.ai/learn",
+                            "description": "Delve into quantum computing, quantum chemistry, and quantum machine learning.",
+                        },
+                    ],
+                },
+            ],
+        },
+    ],
+    "cardSections": [
+        {
+            "header": "Featured",
+            "type": "featured",
+            "cards": [
+                {
+                    "variant": "white",
+                    "title": "Research",
+                    "description": "Use **the world's largest quantum demo library** to publish breakthrough research.",
+                    "imageSrc": "https://assets.cloud.pennylane.ai/navbar/why-pennylane-research-small.png",
+                    "imageSize": "small",
+                    "button": {
+                        "text": "Research with PennyLane",
+                        "variant": "primary",
+                    },
+                    "href": "https://pennylane.ai/research",
+                },
+                {
+                    "variant": "white",
+                    "title": "Teach",
+                    "description": "Elevate your curriculum using **industry-standard tools** that build job-ready skills.",
+                    "imageSrc": "https://assets.cloud.pennylane.ai/navbar/why-pennylane-teach-small.png",
+                    "imageSize": "small",
+                    "button": {
+                        "text": "Explore educator resources",
+                        "variant": "primary",
+                    },
+                    "href": "https://pennylane.ai/education",
+                },
+            ],
+        },
+    ],
+}
+
+DOCUMENTATION = {
+    "name": "Documentation",
+    "linkSections": [
+        {
+            "columns": 1,
+            "sections": [
+                {
+                    "header": "Documentation",
+                    "items": [
+                        {
+                            "name": "Install",
+                            "href": "https://pennylane.ai/install",
+                        },
+                        {
+                            "name": "PennyLane documentation",
+                            "href": "https://docs.pennylane.ai/en/stable/",
+                        },
+                        {
+                            "name": "Catalyst documentation",
+                            "href": "https://docs.pennylane.ai/projects/catalyst/en/stable/",
+                        },
+                        {
+                            "name": "Development guide",
+                            "href": "https://docs.pennylane.ai/en/stable/development/guide.html",
+                        },
+                        {
+                            "name": "How-to guides",
+                            "href": "https://pennylane.ai/search/?contentType=DEMO&categories=how-to&sort=publication_date",
+                        },
+                        {
+                            "name": "API",
+                            "href": "https://docs.pennylane.ai/en/stable/code/qp.html",
+                        },
+                        {
+                            "name": "GitHub",
+                            "href": "https://github.com/PennyLaneAI/pennylane",
+                        },
+                    ],
+                },
+            ],
+        },
+    ],
+    "cardSections": [
+        {
+            "header": "Getting Started",
+            "type": "featured",
+            "cards": [
+                {
+                    "variant": "white",
+                    "title": "PennyLane Fundamentals",
+                    "description": "Begin with a crash course on the basics of PennyLane for quantum practitioners.",
+                    "imageSrc": "https://assets.cloud.pennylane.ai/navbar/documentation-fundamentals-wide.png",
+                    "imageSize": "full",
+                    "button": {
+                        "text": "Get started",
+                        "variant": "secondary",
+                    },
+                    "href": "https://pennylane.ai/codebook/pennylane-fundamentals",
+                },
+                {
+                    "variant": "white",
+                    "title": "Documentation",
+                    "description": "Explore our quantum software API references and development guides.",
+                    "imageSrc": "https://assets.cloud.pennylane.ai/navbar/documentation-documentation-wide.png",
+                    "imageSize": "full",
+                    "button": {
+                        "text": "View documentation",
+                        "variant": "primary",
+                    },
+                    "href": "https://docs.pennylane.ai/en/stable/",
+                },
+            ],
+        },
+        {
+            "header": "Latest Release",
+            "type": "release",
+            "cards": {
+                "limit": 1,
+                "variant": "primary-blue",
+                "button": {
+                    "text": "New in this release",
+                    "variant": "secondary",
+                    "icon": "BiRightArrowAlt",
+                },
+            },
+        },
+    ],
+}
+
+RESOURCES = {
+    "name": "Resources",
+    "linkSections": [
+        {
+            "columns": 2,
+            "sections": [
+                {
+                    "header": "Quantum Computing Resources",
+                    "items": [
+                        {
+                            "name": "Codebook",
+                            "href": "https://pennylane.ai/codebook",
+                            "icon": "BiBookOpen",
+                            "description": "Learn quantum computing with PennyLane.",
+                        },
+                        {
+                            "name": "Coding challenges",
+                            "href": "https://pennylane.ai/challenges",
+                            "icon": "BiTrophy",
+                            "description": "Test your skills with quantum coding challenges and earn badges.",
+                        },
+                        {
+                            "name": "Videos",
+                            "href": "https://pennylane.ai/videos",
+                            "icon": "BiVideo",
+                            "description": "Sit back and explore our curated selection of expert videos.",
+                        },
+                        {
+                            "name": "Demos library",
+                            "href": "https://pennylane.ai/demonstrations",
+                            "icon": "BiSolidFlask",
+                            "description": "Explore the quantum landscape with our research-level demos written by experts.",
+                        },
+                        {
+                            "name": "Compilation hub",
+                            "href": "https://pennylane.ai/compilation",
+                            "icon": "BiCodeBlock",
+                            "description": "Find explanations and implementations of important quantum compilation techniques.",
+                        },
+                        {
+                            "name": "Quantum datasets",
+                            "href": "https://pennylane.ai/datasets",
+                            "icon": "BiData",
+                            "description": "Speed up research with quantum datasets tailored for use with PennyLane.",
+                        },
+                    ],
+                    "cta": {"text": "Browse all", "href": "https://pennylane.ai/search"},
+                },
+            ],
+        },
+    ],
+    "cardSections": [
+        {
+            "header": "Latest Quantum Computing Demos",
+            "type": "content",
+            "cta": {
+                "text": "Explore demos library",
+                "href": "https://pennylane.ai/demonstrations",
+            },
+            "cards": {
+                "limit": 2,
+                "filters": {
+                    "contentType": "DEMO",
+                    "sort": "publication_date",
+                    "categories": ["quantum computing"],
+                },
+                "fallbackImageSrc": "https://assets.cloud.pennylane.ai/navbar/pennylane-generic-demo-thumbnail.png",
+            },
+        },
+    ],
+}
+
+TOPIC_GUIDES = {
+    "name": "Topic Guides",
+    "linkSections": [
+        {
+            "columns": 2,
+            "sections": [
+                {
+                    "header": "Quantum Computing Topic Guides from PennyLane",
+                    "items": [
+                        {
+                            "name": "Fault-tolerant quantum computing",
+                            "href": "https://pennylane.ai/topics/fault-tolerant-quantum-computing",
+                            "description": "Master the latest advancements in error correcting codes and FTQC.",
+                        },
+                        {
+                            "name": "Hamiltonian simulation",
+                            "href": "https://pennylane.ai/topics/hamiltonian-simulation",
+                            "description": "Discover Hamiltonian simulation algorithms-from basic to advanced techniques.",
+                        },
+                        {
+                            "name": "Quantum compilation",
+                            "href": "https://pennylane.ai/topics/quantum-compilation",
+                            "pill": {
+                                "text": "New",
+                                "variant": "in-progress",
+                                # TODO: Update start and expiry dates
+                                "startDate": "2026-05-01",
+                                "expiryDate": "2026-07-01",
+                            },
+                            "description": "Explore the definitive PennyLane Guide to quantum compilation techniques.",
+                        },
+                        {
+                            "name": "Quantum gradients",
+                            "href": "https://pennylane.ai/topics/quantum-gradients",
+                            "description": "Access a curated guide of the different quantum gradient methods.",
+                        },
+                        {
+                            "name": "Quantum hardware",
+                            "href": "https://pennylane.ai/topics/quantum-hardware",
+                            "description": "View how the modalities stack up in the global race to build a scalable quantum computer.",
+                        },
+                        {
+                            "name": "Quantum machine learning",
+                            "href": "https://pennylane.ai/topics/quantum-machine-learning",
+                            "description": "Learn the different flavours of quantum machine learning in this curated guide.",
+                        },
+                    ],
+                },
+            ],
+        },
+    ],
+    "cardSections": [
+        {
+            "header": "Featured PennyLane Topic Guides",
+            "type": "featured",
+            "cards": [
+                {
+                    "variant": "white",
+                    "title": "Fault-tolerant quantum computing",
+                    "description": "Master the latest advancements in error correcting codes and FTQC.",
+                    "imageSrc": "https://assets.cloud.pennylane.ai/navbar/topic-guides-ftqc-wide.png",
+                    "imageSize": "full",
+                    "button": {
+                        "text": "Demystify FTQC",
+                        "variant": "secondary",
+                    },
+                    "href": "https://pennylane.ai/codebook/pennylane-fundamentals",
+                },
+                {
+                    "variant": "white",
+                    "title": "Quantum compilation",
+                    "description": "Explore the definitive PennyLane Guide to quantum compilation techniques.",
+                    "imageSrc": "https://assets.cloud.pennylane.ai/navbar/topic-guides-compilation-wide.png",
+                    "imageSize": "full",
+                    "button": {
+                        "text": "Explore quantum compilation",
+                        "variant": "secondary",
+                    },
+                    "href": "https://docs.pennylane.ai/en/stable/",
+                    "pill": {
+                        "text": "New",
+                        "variant": "in-progress",
+                        # TODO: Add start and expiry dates
+                    },
+                },
+            ],
+        },
+    ],
+}
+
+COMMUNITY_SUPPORT = {
+    "name": "Community & Support",
+    "pill": {
+        "text": "New",
+        "variant": "info",
+        # TODO: Add start and expiry dates
+    },
+    "linkSections": [
+        {
+            "columns": 1,
+            "sections": [
+                {
+                    "header": "Community & Support",
+                    "items": [
+                        {
+                            "name": "PennyLane blog",
+                            "href": "https://pennylane.ai/blog?page=1",
+                        },
+                        {
+                            "name": "FAQs",
+                            "href": "https://pennylane.ai/faq",
+                        },
+                        {
+                            "name": "Discussion forum",
+                            "href": "https://discuss.pennylane.ai",
+                        },
+                        {
+                            "name": "Submit a demo",
+                            "href": "https://pennylane.ai/demos_submission",
+                        },
+                        {
+                            "name": "Get involved",
+                            "href": "https://pennylane.ai/get-involved",
+                        },
+                    ],
+                },
+                {
+                    "header": "From Xanadu",
+                    "items": [
+                        {
+                            "name": "Xanadu blog",
+                            "href": "https://xanadu.ai/blog",
+                        },
+                        {
+                            "name": "Xanadu press and news",
+                            "href": "https://xanadu.ai/press",
+                        },
+                    ],
+                },
+            ],
+        },
+    ],
+    "cardSections": [
+        {
+            "header": "Latest Blog Post",
+            "type": "content",
+            "cta": {"text": "View all", "href": "https://pennylane.ai/blog?page=1"},
+            "cards": {
+                "limit": 1,
+                "filters": {
+                    "contentType": "BLOG",
+                    "sort": "publication_date",
+                },
+                "fallbackImageSrc": "https://assets.cloud.pennylane.ai/navbar/pennylane-generic-blog-thumbnail.png",
+            },
+        },
+        {
+            "header": "Help & Support",
+            "type": "featured",
+            "cards": [
+                {
+                    "variant": "white",
+                    "title": "Join the PennyLane discussion forum",
+                    "description": "Get expert help and connect with the global PennyLane community.",
+                    "imageSrc": "https://assets.cloud.pennylane.ai/navbar/community-forum-small.png",
+                    "imageSize": "small",
+                    "button": {
+                        "text": "Go to forum",
+                        "variant": "secondary",
+                        "icon": "BiLinkExternal",
+                    },
+                    "href": "https://discuss.pennylane.ai",
+                },
+            ],
+        },
+        {
+            "header": "PennyLane newsletter",
+            "type": "featured",
+            "cards": [
+                {
+                    "variant": "primary-blue",
+                    "title": "PennyLane newsletter",
+                    "description": "Want to get the latest quantum updates delivered to your inbox? Join the list.",
+                    "imageSrc": "https://assets.cloud.pennylane.ai/navbar/newsletter-small.png",
+                    "imageSize": "small",
+                    "button": {
+                        "text": "Subscribe now",
+                        "variant": "secondary",
+                        "icon": "BiRightArrowAlt",
+                    },
+                    "href": "https://bit.ly/434uPcQ",
+                    "pill": {
+                        "text": "New",
+                        "variant": "info",
+                        # TODO: Add start and expiry dates
+                    },
+                },
+            ],
+        },
+    ],
+}
+
+
 NAVBAR_LEFT = [
-    {
-        "name": "About",
-        "dropdown": [
-            {
-                "name": "Research",
-                "href": "https://pennylane.ai/research",
-            },
-            {
-                "name": "Features",
-                "href": "https://pennylane.ai/features",
-            },
-            {
-                "name": "Performance",
-                "href": "https://pennylane.ai/performance",
-            },
-            {
-                "name": "Hardware & Simulators",
-                "href": "https://pennylane.ai/devices",
-            },
-            {
-                "name": "Learn",
-                "href": "https://pennylane.ai/qml",
-            },
-            {
-                "name": "Teach",
-                "href": "https://pennylane.ai/education",
-            },
-        ],
-    },
-    {
-        "name": "Software & Documentation",
-        "dropdown": [
-            {
-                "name": "Install PennyLane",
-                "href": "https://pennylane.ai/install",
-            },
-            {
-                "name": "Documentation",
-                "href": "https://docs.pennylane.ai/en/stable/",
-            },
-            {
-                "name": "Catalyst Compilation Docs",
-                "href": "https://docs.pennylane.ai/projects/catalyst/en/stable/",
-            },
-            {
-                "name": "Development Guide",
-                "href": "https://docs.pennylane.ai/en/stable/development/guide.html",
-            },
-            {
-                "name": "How-to Demos",
-                "href": "https://pennylane.ai/search/?contentType=DEMO&categories=how-to&sort=publication_date",
-            },
-            {
-                "name": "API",
-                "href": "https://docs.pennylane.ai/en/stable/code/qml.html",
-            },
-            {
-                "name": "GitHub",
-                "href": "https://github.com/PennyLaneAI/pennylane",
-                "external": True,
-            },
-        ],
-    },
-    {
-        "name": "Resources",
-        "dropdown": [
-            {
-                "name": "Demos",
-                "href": "https://pennylane.ai/qml/demonstrations",
-            },
-            {
-                "name": "Compilation Hub",
-                "href": "https://pennylane.ai/compilation",
-            },
-            {
-                "name": "Quantum Datasets",
-                "href": "https://pennylane.ai/datasets",
-            },
-            {
-                "name": "Codebook",
-                "href": "https://pennylane.ai/codebook",
-            },
-            {
-                "name": "Coding Challenges",
-                "href": "https://pennylane.ai/challenges",
-            },
-            {
-                "name": "Videos",
-                "href": "https://pennylane.ai/qml/videos",
-            },
-        ],
-    },
-    {
-        "name": "Topics",
-        "dropdown": [
-            {
-                "name": "Fault-Tolerant Quantum Computing",
-                "href": "https://pennylane.ai/topics/fault-tolerant-quantum-computing",
-            },
-            {
-                "name": "Hamiltonian Simulation",
-                "href": "https://pennylane.ai/topics/hamiltonian-simulation",
-            },
-            {
-                "name": "Quantum Compilation",
-                "href": "https://pennylane.ai/topics/quantum-compilation",
-            },
-            {
-                "name": "Quantum Hardware",
-                "href": "https://pennylane.ai/topics/quantum-hardware",
-            },
-            {
-                "name": "Quantum Machine Learning",
-                "href": "https://pennylane.ai/topics/quantum-machine-learning",
-            },
-            {
-                "name": "Quantum Gradients",
-                "href": "https://pennylane.ai/topics/quantum-gradients",
-            },
-        ],
-    },
-    {
-        "name": "Community & Support",
-        "dropdown": [
-            {
-                "name": "Blog",
-                "href": "https://pennylane.ai/blog/?page=1",
-            },
-            {
-                "name": "FAQs",
-                "href": "https://pennylane.ai/faq",
-            },
-            {
-                "name": "Discussion Forum",
-                "href": "https://discuss.pennylane.ai/",
-                "external": True,
-            },
-            {
-                "name": "Submit a Demo",
-                "href": "https://pennylane.ai/qml/demos_submission",
-            },
-            {
-                "name": "Get Involved",
-                "href": "https://pennylane.ai/get-involved",
-            },
-        ],
-    },
+    WHY_PENNYLANE,
+    DOCUMENTATION,
+    RESOURCES,
+    TOPIC_GUIDES,
+    COMMUNITY_SUPPORT,
 ]
 
 

--- a/pennylane_sphinx_theme/navbar.py
+++ b/pennylane_sphinx_theme/navbar.py
@@ -123,7 +123,9 @@ DOCUMENTATION = {
                         },
                         {
                             "name": "How-to guides",
-                            "href": pl("/search/?contentType=DEMO&categories=how-to&sort=publication_date"),
+                            "href": pl(
+                                "/search/?contentType=DEMO&categories=how-to&sort=publication_date"
+                            ),
                         },
                         {
                             "name": "API",

--- a/pennylane_sphinx_theme/navbar.py
+++ b/pennylane_sphinx_theme/navbar.py
@@ -1,5 +1,9 @@
 """
 This module contains the common PennyLane navigation bar data.
+
+Icon values are Boxicons CSS classes (e.g. "bx-book-open", "bxs-flask"), since
+the theme renders icons with the Boxicons web font. Pick any icon from
+https://boxicons.com and use its class name directly.
 """
 
 WHY_PENNYLANE = {
@@ -172,7 +176,7 @@ DOCUMENTATION = {
                 "button": {
                     "text": "New in this release",
                     "variant": "secondary",
-                    "icon": "BiRightArrowAlt",
+                    "icon": "bx-right-arrow-alt",
                 },
             },
         },
@@ -191,37 +195,37 @@ RESOURCES = {
                         {
                             "name": "Codebook",
                             "href": "https://pennylane.ai/codebook",
-                            "icon": "BiBookOpen",
+                            "icon": "bx-book-open",
                             "description": "Learn quantum computing with PennyLane.",
                         },
                         {
                             "name": "Coding challenges",
                             "href": "https://pennylane.ai/challenges",
-                            "icon": "BiTrophy",
+                            "icon": "bx-trophy",
                             "description": "Test your skills with quantum coding challenges and earn badges.",
                         },
                         {
                             "name": "Videos",
                             "href": "https://pennylane.ai/videos",
-                            "icon": "BiVideo",
+                            "icon": "bx-video",
                             "description": "Sit back and explore our curated selection of expert videos.",
                         },
                         {
                             "name": "Demos library",
                             "href": "https://pennylane.ai/demonstrations",
-                            "icon": "BiSolidFlask",
+                            "icon": "bxs-flask",
                             "description": "Explore the quantum landscape with our research-level demos written by experts.",
                         },
                         {
                             "name": "Compilation hub",
                             "href": "https://pennylane.ai/compilation",
-                            "icon": "BiCodeBlock",
+                            "icon": "bx-code-block",
                             "description": "Find explanations and implementations of important quantum compilation techniques.",
                         },
                         {
                             "name": "Quantum datasets",
                             "href": "https://pennylane.ai/datasets",
-                            "icon": "BiData",
+                            "icon": "bx-data",
                             "description": "Speed up research with quantum datasets tailored for use with PennyLane.",
                         },
                     ],
@@ -268,7 +272,7 @@ TOPIC_GUIDES = {
                         {
                             "name": "Hamiltonian simulation",
                             "href": "https://pennylane.ai/topics/hamiltonian-simulation",
-                            "description": "Discover Hamiltonian simulation algorithms-from basic to advanced techniques.",
+                            "description": "Discover Hamiltonian simulation algorithms–from basic to advanced techniques.",
                         },
                         {
                             "name": "Quantum compilation",
@@ -420,7 +424,7 @@ COMMUNITY_SUPPORT = {
                     "button": {
                         "text": "Go to forum",
                         "variant": "secondary",
-                        "icon": "BiLinkExternal",
+                        "icon": "bx-link-external",
                     },
                     "href": "https://discuss.pennylane.ai",
                 },
@@ -439,7 +443,7 @@ COMMUNITY_SUPPORT = {
                     "button": {
                         "text": "Subscribe now",
                         "variant": "secondary",
-                        "icon": "BiRightArrowAlt",
+                        "icon": "bx-right-arrow-alt",
                     },
                     "href": "https://bit.ly/434uPcQ",
                     "pill": {

--- a/pennylane_sphinx_theme/navbar.py
+++ b/pennylane_sphinx_theme/navbar.py
@@ -6,7 +6,7 @@ the theme renders icons with the Boxicons web font. Pick any icon from
 https://boxicons.com and use its class name directly.
 """
 
-from .urls import pl
+from .urls import pl_url
 
 WHY_PENNYLANE = {
     "name": "Why PennyLane",
@@ -19,17 +19,17 @@ WHY_PENNYLANE = {
                     "items": [
                         {
                             "name": "Features",
-                            "href": pl("/features"),
+                            "href": pl_url("/features"),
                             "description": "Discover easy-to-use PennyLane features to empower your work.",
                         },
                         {
                             "name": "Performance",
-                            "href": pl("/performance"),
+                            "href": pl_url("/performance"),
                             "description": "Scale up your workflows on GPUs and supercomputers to accelerate simulations.",
                         },
                         {
                             "name": "Hardware and simulators",
-                            "href": pl("/devices"),
+                            "href": pl_url("/devices"),
                             "description": "Explore PennyLane's quantum device ecosystem with 40+ integrated options.",
                         },
                     ],
@@ -44,17 +44,17 @@ WHY_PENNYLANE = {
                     "items": [
                         {
                             "name": "Research",
-                            "href": pl("/research"),
+                            "href": pl_url("/research"),
                             "description": "Accelerate your quantum computing research breakthroughs with PennyLane.",
                         },
                         {
                             "name": "Teach",
-                            "href": pl("/education"),
+                            "href": pl_url("/education"),
                             "description": "Join quantum educators in over 150 universities using PennyLane in the classroom.",
                         },
                         {
                             "name": "Learn",
-                            "href": pl("/learn"),
+                            "href": pl_url("/learn"),
                             "description": "Delve into quantum computing, quantum chemistry, and quantum machine learning.",
                         },
                     ],
@@ -77,7 +77,7 @@ WHY_PENNYLANE = {
                         "text": "Research with PennyLane",
                         "variant": "primary",
                     },
-                    "href": pl("/research"),
+                    "href": pl_url("/research"),
                 },
                 {
                     "variant": "white",
@@ -89,7 +89,7 @@ WHY_PENNYLANE = {
                         "text": "Explore educator resources",
                         "variant": "primary",
                     },
-                    "href": pl("/education"),
+                    "href": pl_url("/education"),
                 },
             ],
         },
@@ -107,7 +107,7 @@ DOCUMENTATION = {
                     "items": [
                         {
                             "name": "Install",
-                            "href": pl("/install"),
+                            "href": pl_url("/install"),
                         },
                         {
                             "name": "PennyLane documentation",
@@ -123,7 +123,7 @@ DOCUMENTATION = {
                         },
                         {
                             "name": "How-to guides",
-                            "href": pl(
+                            "href": pl_url(
                                 "/search/?contentType=DEMO&categories=how-to&sort=publication_date"
                             ),
                         },
@@ -155,7 +155,7 @@ DOCUMENTATION = {
                         "text": "Get started",
                         "variant": "secondary",
                     },
-                    "href": pl("/codebook/pennylane-fundamentals"),
+                    "href": pl_url("/codebook/pennylane-fundamentals"),
                 },
                 {
                     "variant": "white",
@@ -198,42 +198,42 @@ RESOURCES = {
                     "items": [
                         {
                             "name": "Codebook",
-                            "href": pl("/codebook"),
+                            "href": pl_url("/codebook"),
                             "icon": "bx-book-open",
                             "description": "Learn quantum computing with PennyLane.",
                         },
                         {
                             "name": "Coding challenges",
-                            "href": pl("/challenges"),
+                            "href": pl_url("/challenges"),
                             "icon": "bx-trophy",
                             "description": "Test your skills with quantum coding challenges and earn badges.",
                         },
                         {
                             "name": "Videos",
-                            "href": pl("/videos"),
+                            "href": pl_url("/videos"),
                             "icon": "bx-video",
                             "description": "Sit back and explore our curated selection of expert videos.",
                         },
                         {
                             "name": "Demos library",
-                            "href": pl("/demonstrations"),
+                            "href": pl_url("/demonstrations"),
                             "icon": "bxs-flask",
                             "description": "Explore the quantum landscape with our research-level demos written by experts.",
                         },
                         {
                             "name": "Compilation hub",
-                            "href": pl("/compilation"),
+                            "href": pl_url("/compilation"),
                             "icon": "bx-code-block",
                             "description": "Find explanations and implementations of important quantum compilation techniques.",
                         },
                         {
                             "name": "Quantum datasets",
-                            "href": pl("/datasets"),
+                            "href": pl_url("/datasets"),
                             "icon": "bx-data",
                             "description": "Speed up research with quantum datasets tailored for use with PennyLane.",
                         },
                     ],
-                    "cta": {"text": "Browse all", "href": pl("/search")},
+                    "cta": {"text": "Browse all", "href": pl_url("/search")},
                 },
             ],
         },
@@ -244,7 +244,7 @@ RESOURCES = {
             "type": "content",
             "cta": {
                 "text": "Explore demos library",
-                "href": pl("/demonstrations"),
+                "href": pl_url("/demonstrations"),
             },
             "cards": {
                 "limit": 2,
@@ -270,21 +270,20 @@ TOPIC_GUIDES = {
                     "items": [
                         {
                             "name": "Fault-tolerant quantum computing",
-                            "href": pl("/topics/fault-tolerant-quantum-computing"),
+                            "href": pl_url("/topics/fault-tolerant-quantum-computing"),
                             "description": "Master the latest advancements in error correcting codes and FTQC.",
                         },
                         {
                             "name": "Hamiltonian simulation",
-                            "href": pl("/topics/hamiltonian-simulation"),
+                            "href": pl_url("/topics/hamiltonian-simulation"),
                             "description": "Discover Hamiltonian simulation algorithms–from basic to advanced techniques.",
                         },
                         {
                             "name": "Quantum compilation",
-                            "href": pl("/topics/quantum-compilation"),
+                            "href": pl_url("/topics/quantum-compilation"),
                             "pill": {
                                 "text": "New",
                                 "variant": "in-progress",
-                                # TODO: Update start and expiry dates
                                 "startDate": "2026-05-01",
                                 "expiryDate": "2026-07-01",
                             },
@@ -292,17 +291,17 @@ TOPIC_GUIDES = {
                         },
                         {
                             "name": "Quantum gradients",
-                            "href": pl("/topics/quantum-gradients"),
+                            "href": pl_url("/topics/quantum-gradients"),
                             "description": "Access a curated guide of the different quantum gradient methods.",
                         },
                         {
                             "name": "Quantum hardware",
-                            "href": pl("/topics/quantum-hardware"),
+                            "href": pl_url("/topics/quantum-hardware"),
                             "description": "View how the modalities stack up in the global race to build a scalable quantum computer.",
                         },
                         {
                             "name": "Quantum machine learning",
-                            "href": pl("/topics/quantum-machine-learning"),
+                            "href": pl_url("/topics/quantum-machine-learning"),
                             "description": "Learn the different flavours of quantum machine learning in this curated guide.",
                         },
                     ],
@@ -325,7 +324,7 @@ TOPIC_GUIDES = {
                         "text": "Demystify FTQC",
                         "variant": "secondary",
                     },
-                    "href": pl("/topics/fault-tolerant-quantum-computing"),
+                    "href": pl_url("/topics/fault-tolerant-quantum-computing"),
                 },
                 {
                     "variant": "white",
@@ -337,11 +336,10 @@ TOPIC_GUIDES = {
                         "text": "Explore quantum compilation",
                         "variant": "secondary",
                     },
-                    "href": pl("/topics/quantum-compilation"),
+                    "href": pl_url("/topics/quantum-compilation"),
                     "pill": {
                         "text": "New",
                         "variant": "in-progress",
-                        # TODO: Add start and expiry dates
                     },
                 },
             ],
@@ -354,7 +352,6 @@ COMMUNITY_SUPPORT = {
     "pill": {
         "text": "New",
         "variant": "info",
-        # TODO: Add start and expiry dates
     },
     "linkSections": [
         {
@@ -365,11 +362,11 @@ COMMUNITY_SUPPORT = {
                     "items": [
                         {
                             "name": "PennyLane blog",
-                            "href": pl("/blog?page=1"),
+                            "href": pl_url("/blog?page=1"),
                         },
                         {
                             "name": "FAQs",
-                            "href": pl("/faq"),
+                            "href": pl_url("/faq"),
                         },
                         {
                             "name": "Discussion forum",
@@ -377,11 +374,11 @@ COMMUNITY_SUPPORT = {
                         },
                         {
                             "name": "Submit a demo",
-                            "href": pl("/demos_submission"),
+                            "href": pl_url("/demos_submission"),
                         },
                         {
                             "name": "Get involved",
-                            "href": pl("/get-involved"),
+                            "href": pl_url("/get-involved"),
                         },
                     ],
                 },
@@ -405,7 +402,7 @@ COMMUNITY_SUPPORT = {
         {
             "header": "Latest Blog Post",
             "type": "content",
-            "cta": {"text": "View all", "href": pl("/blog?page=1")},
+            "cta": {"text": "View all", "href": pl_url("/blog?page=1")},
             "cards": {
                 "limit": 1,
                 "filters": {
@@ -453,7 +450,6 @@ COMMUNITY_SUPPORT = {
                     "pill": {
                         "text": "New",
                         "variant": "info",
-                        # TODO: Add start and expiry dates
                     },
                 },
             ],
@@ -474,6 +470,6 @@ NAVBAR_LEFT = [
 NAVBAR_RIGHT = [
     {
         "name": "Install",
-        "href": pl("/install"),
+        "href": pl_url("/install"),
     },
 ]

--- a/pennylane_sphinx_theme/navbar.py
+++ b/pennylane_sphinx_theme/navbar.py
@@ -6,6 +6,8 @@ the theme renders icons with the Boxicons web font. Pick any icon from
 https://boxicons.com and use its class name directly.
 """
 
+from .urls import pl
+
 WHY_PENNYLANE = {
     "name": "Why PennyLane",
     "linkSections": [
@@ -17,17 +19,17 @@ WHY_PENNYLANE = {
                     "items": [
                         {
                             "name": "Features",
-                            "href": "https://pennylane.ai/features",
+                            "href": pl("/features"),
                             "description": "Discover easy-to-use PennyLane features to empower your work.",
                         },
                         {
                             "name": "Performance",
-                            "href": "https://pennylane.ai/performance",
+                            "href": pl("/performance"),
                             "description": "Scale up your workflows on GPUs and supercomputers to accelerate simulations.",
                         },
                         {
                             "name": "Hardware and simulators",
-                            "href": "https://pennylane.ai/devices",
+                            "href": pl("/devices"),
                             "description": "Explore PennyLane's quantum device ecosystem with 40+ integrated options.",
                         },
                     ],
@@ -42,17 +44,17 @@ WHY_PENNYLANE = {
                     "items": [
                         {
                             "name": "Research",
-                            "href": "https://pennylane.ai/research",
+                            "href": pl("/research"),
                             "description": "Accelerate your quantum computing research breakthroughs with PennyLane.",
                         },
                         {
                             "name": "Teach",
-                            "href": "https://pennylane.ai/education",
-                            "description": "Join quantum educators in over 130 universities using PennyLane in the classroom.",
+                            "href": pl("/education"),
+                            "description": "Join quantum educators in over 150 universities using PennyLane in the classroom.",
                         },
                         {
                             "name": "Learn",
-                            "href": "https://pennylane.ai/learn",
+                            "href": pl("/learn"),
                             "description": "Delve into quantum computing, quantum chemistry, and quantum machine learning.",
                         },
                     ],
@@ -75,7 +77,7 @@ WHY_PENNYLANE = {
                         "text": "Research with PennyLane",
                         "variant": "primary",
                     },
-                    "href": "https://pennylane.ai/research",
+                    "href": pl("/research"),
                 },
                 {
                     "variant": "white",
@@ -87,7 +89,7 @@ WHY_PENNYLANE = {
                         "text": "Explore educator resources",
                         "variant": "primary",
                     },
-                    "href": "https://pennylane.ai/education",
+                    "href": pl("/education"),
                 },
             ],
         },
@@ -105,7 +107,7 @@ DOCUMENTATION = {
                     "items": [
                         {
                             "name": "Install",
-                            "href": "https://pennylane.ai/install",
+                            "href": pl("/install"),
                         },
                         {
                             "name": "PennyLane documentation",
@@ -121,7 +123,7 @@ DOCUMENTATION = {
                         },
                         {
                             "name": "How-to guides",
-                            "href": "https://pennylane.ai/search/?contentType=DEMO&categories=how-to&sort=publication_date",
+                            "href": pl("/search/?contentType=DEMO&categories=how-to&sort=publication_date"),
                         },
                         {
                             "name": "API",
@@ -151,7 +153,7 @@ DOCUMENTATION = {
                         "text": "Get started",
                         "variant": "secondary",
                     },
-                    "href": "https://pennylane.ai/codebook/pennylane-fundamentals",
+                    "href": pl("/codebook/pennylane-fundamentals"),
                 },
                 {
                     "variant": "white",
@@ -194,42 +196,42 @@ RESOURCES = {
                     "items": [
                         {
                             "name": "Codebook",
-                            "href": "https://pennylane.ai/codebook",
+                            "href": pl("/codebook"),
                             "icon": "bx-book-open",
                             "description": "Learn quantum computing with PennyLane.",
                         },
                         {
                             "name": "Coding challenges",
-                            "href": "https://pennylane.ai/challenges",
+                            "href": pl("/challenges"),
                             "icon": "bx-trophy",
                             "description": "Test your skills with quantum coding challenges and earn badges.",
                         },
                         {
                             "name": "Videos",
-                            "href": "https://pennylane.ai/videos",
+                            "href": pl("/videos"),
                             "icon": "bx-video",
                             "description": "Sit back and explore our curated selection of expert videos.",
                         },
                         {
                             "name": "Demos library",
-                            "href": "https://pennylane.ai/demonstrations",
+                            "href": pl("/demonstrations"),
                             "icon": "bxs-flask",
                             "description": "Explore the quantum landscape with our research-level demos written by experts.",
                         },
                         {
                             "name": "Compilation hub",
-                            "href": "https://pennylane.ai/compilation",
+                            "href": pl("/compilation"),
                             "icon": "bx-code-block",
                             "description": "Find explanations and implementations of important quantum compilation techniques.",
                         },
                         {
                             "name": "Quantum datasets",
-                            "href": "https://pennylane.ai/datasets",
+                            "href": pl("/datasets"),
                             "icon": "bx-data",
                             "description": "Speed up research with quantum datasets tailored for use with PennyLane.",
                         },
                     ],
-                    "cta": {"text": "Browse all", "href": "https://pennylane.ai/search"},
+                    "cta": {"text": "Browse all", "href": pl("/search")},
                 },
             ],
         },
@@ -240,7 +242,7 @@ RESOURCES = {
             "type": "content",
             "cta": {
                 "text": "Explore demos library",
-                "href": "https://pennylane.ai/demonstrations",
+                "href": pl("/demonstrations"),
             },
             "cards": {
                 "limit": 2,
@@ -266,17 +268,17 @@ TOPIC_GUIDES = {
                     "items": [
                         {
                             "name": "Fault-tolerant quantum computing",
-                            "href": "https://pennylane.ai/topics/fault-tolerant-quantum-computing",
+                            "href": pl("/topics/fault-tolerant-quantum-computing"),
                             "description": "Master the latest advancements in error correcting codes and FTQC.",
                         },
                         {
                             "name": "Hamiltonian simulation",
-                            "href": "https://pennylane.ai/topics/hamiltonian-simulation",
+                            "href": pl("/topics/hamiltonian-simulation"),
                             "description": "Discover Hamiltonian simulation algorithms–from basic to advanced techniques.",
                         },
                         {
                             "name": "Quantum compilation",
-                            "href": "https://pennylane.ai/topics/quantum-compilation",
+                            "href": pl("/topics/quantum-compilation"),
                             "pill": {
                                 "text": "New",
                                 "variant": "in-progress",
@@ -288,17 +290,17 @@ TOPIC_GUIDES = {
                         },
                         {
                             "name": "Quantum gradients",
-                            "href": "https://pennylane.ai/topics/quantum-gradients",
+                            "href": pl("/topics/quantum-gradients"),
                             "description": "Access a curated guide of the different quantum gradient methods.",
                         },
                         {
                             "name": "Quantum hardware",
-                            "href": "https://pennylane.ai/topics/quantum-hardware",
+                            "href": pl("/topics/quantum-hardware"),
                             "description": "View how the modalities stack up in the global race to build a scalable quantum computer.",
                         },
                         {
                             "name": "Quantum machine learning",
-                            "href": "https://pennylane.ai/topics/quantum-machine-learning",
+                            "href": pl("/topics/quantum-machine-learning"),
                             "description": "Learn the different flavours of quantum machine learning in this curated guide.",
                         },
                     ],
@@ -321,7 +323,7 @@ TOPIC_GUIDES = {
                         "text": "Demystify FTQC",
                         "variant": "secondary",
                     },
-                    "href": "https://pennylane.ai/codebook/pennylane-fundamentals",
+                    "href": pl("/topics/fault-tolerant-quantum-computing"),
                 },
                 {
                     "variant": "white",
@@ -333,7 +335,7 @@ TOPIC_GUIDES = {
                         "text": "Explore quantum compilation",
                         "variant": "secondary",
                     },
-                    "href": "https://docs.pennylane.ai/en/stable/",
+                    "href": pl("/topics/quantum-compilation"),
                     "pill": {
                         "text": "New",
                         "variant": "in-progress",
@@ -361,11 +363,11 @@ COMMUNITY_SUPPORT = {
                     "items": [
                         {
                             "name": "PennyLane blog",
-                            "href": "https://pennylane.ai/blog?page=1",
+                            "href": pl("/blog?page=1"),
                         },
                         {
                             "name": "FAQs",
-                            "href": "https://pennylane.ai/faq",
+                            "href": pl("/faq"),
                         },
                         {
                             "name": "Discussion forum",
@@ -373,11 +375,11 @@ COMMUNITY_SUPPORT = {
                         },
                         {
                             "name": "Submit a demo",
-                            "href": "https://pennylane.ai/demos_submission",
+                            "href": pl("/demos_submission"),
                         },
                         {
                             "name": "Get involved",
-                            "href": "https://pennylane.ai/get-involved",
+                            "href": pl("/get-involved"),
                         },
                     ],
                 },
@@ -401,7 +403,7 @@ COMMUNITY_SUPPORT = {
         {
             "header": "Latest Blog Post",
             "type": "content",
-            "cta": {"text": "View all", "href": "https://pennylane.ai/blog?page=1"},
+            "cta": {"text": "View all", "href": pl("/blog?page=1")},
             "cards": {
                 "limit": 1,
                 "filters": {
@@ -470,6 +472,6 @@ NAVBAR_LEFT = [
 NAVBAR_RIGHT = [
     {
         "name": "Install",
-        "href": "https://pennylane.ai/install",
+        "href": pl("/install"),
     },
 ]

--- a/pennylane_sphinx_theme/theme.conf
+++ b/pennylane_sphinx_theme/theme.conf
@@ -6,7 +6,7 @@ inherit = xanadu
 navbar_name =
 # Path to an image with the project name and wordmark to appear in the navigation bar.
 # Specifying this option will replace the project name and logo in the navigation bar.
-navbar_wordmark_path = https://assets.cloud.pennylane.ai/docs/pennylane-logo-with-wordmark.svg
+navbar_wordmark_path = https://assets.cloud.pennylane.ai/pennylane_website/generic/pennylane-logo.png
 # Alternative text to display in lieu of the wordmark or logo in the navigation bar.
 navbar_logo_alt = PennyLane
 # Path to the project logo to appear in the navigation bar.

--- a/pennylane_sphinx_theme/urls.py
+++ b/pennylane_sphinx_theme/urls.py
@@ -5,7 +5,7 @@ Shared URL helpers and constants for the PennyLane Sphinx theme content.
 PENNYLANE_WEBSITE = "https://pennylane.ai"
 
 
-def pl(path):
+def pl_url(path):
     """Return an absolute pennylane.ai URL for website paths."""
     if path.startswith("http"):
         return path

--- a/pennylane_sphinx_theme/urls.py
+++ b/pennylane_sphinx_theme/urls.py
@@ -1,0 +1,12 @@
+"""
+Shared URL helpers and constants for the PennyLane Sphinx theme content.
+"""
+
+PENNYLANE_WEBSITE = "https://pennylane.ai"
+
+
+def pl(path):
+    """Return an absolute pennylane.ai URL for website paths."""
+    if path.startswith("http"):
+        return path
+    return f"{PENNYLANE_WEBSITE}{path}"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 sphinx==4.5.0
 pillow==10.3.0
 sphinx-gallery==0.10.1
-xanadu-sphinx-theme @ git+https://github.com/XanaduAI/xanadu-sphinx-theme.git@feature/navbar-footer-redesign
+xanadu-sphinx-theme @ git+https://github.com/XanaduAI/xanadu-sphinx-theme.git@sc-121581-port-global-navbar-to-sphinx-documentation

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 sphinx==4.5.0
 pillow==10.3.0
 sphinx-gallery==0.10.1
-xanadu-sphinx-theme @ git+https://github.com/XanaduAI/xanadu-sphinx-theme.git@sc-121581-port-global-navbar-to-sphinx-documentation
+xanadu-sphinx-theme==0.20.0

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("pennylane_sphinx_theme/_version.py") as f:
 
 requirements = [
     "sphinx",
-    "xanadu-sphinx-theme @ git+https://github.com/XanaduAI/xanadu-sphinx-theme.git@feature/navbar-footer-redesign",
+    "xanadu-sphinx-theme @ git+https://github.com/XanaduAI/xanadu-sphinx-theme.git@sc-121581-port-global-navbar-to-sphinx-documentation",
     # The packages below are used to generate thumbnail images.
     "pillow",
     "sphinx-gallery",

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("pennylane_sphinx_theme/_version.py") as f:
 
 requirements = [
     "sphinx",
-    "xanadu-sphinx-theme @ git+https://github.com/XanaduAI/xanadu-sphinx-theme.git@sc-121581-port-global-navbar-to-sphinx-documentation",
+    "xanadu-sphinx-theme==0.20.0",
     # The packages below are used to generate thumbnail images.
     "pillow",
     "sphinx-gallery",


### PR DESCRIPTION
**Context:** 
Port the new global `navbar` to sphinx documentation

**Description of the Change:**

https://github.com/user-attachments/assets/9be534d7-c4c6-4c0d-8277-a5200cb43af9

https://github.com/user-attachments/assets/8c6b9729-2899-497b-bf1a-1418049c197f


Defined the `navbar` content for PennyLane's new global navbar, replacing the old dropdown structure with multi-column link sections (with icons) and featured/content/latest-release cards.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
