### PR TITLE
Footer fix

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,8 +1,15 @@
 ## Release 0.31.0 (development release)
 
+### Bug fixes
+
+- Removed duplicate "tensorflow" copy in the footer.
+- Lowered the mobile/desktop breakpoint 1324px.
+
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
+
+[Koeun Lee](https://github.com/koeun-lee)
 
 ## Release 0.30.0 (current release)
 

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -13,4 +13,4 @@ sphinxcontrib-htmlhelp==2.0.1
 sphinxcontrib-serializinghtml==1.1.5
 sphinx-copybutton
 sphinx-gallery==0.10.1
-xanadu-sphinx-theme==0.20.0
+xanadu-sphinx-theme==0.21.0

--- a/pennylane_sphinx_theme/footer.py
+++ b/pennylane_sphinx_theme/footer.py
@@ -35,11 +35,6 @@ FOOTER = {
         "icon": XANADU_LOGO,
         "href": "https://xanadu.ai",
     },
-    "footer_copyright": {
-        "tensorflow_notice": (
-            "TensorFlow, the TensorFlow logo and any related marks are " "trademarks of Google Inc."
-        ),
-    },
     "footer_policies": [
         {
             "text": "Privacy policy",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 sphinx==4.5.0
 pillow==10.3.0
 sphinx-gallery==0.10.1
-xanadu-sphinx-theme==0.20.0
+xanadu-sphinx-theme==0.21.0

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("pennylane_sphinx_theme/_version.py") as f:
 
 requirements = [
     "sphinx",
-    "xanadu-sphinx-theme==0.20.0",
+    "xanadu-sphinx-theme==0.21.0",
     # The packages below are used to generate thumbnail images.
     "pillow",
     "sphinx-gallery",


### PR DESCRIPTION
**Context:** Navbar & footer fix

**Description of the Change:**
- Removed duplicate "tensorflow" copy in the footer.
- Lowered mobile/desktop navbar breakpoint to 1324px.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**